### PR TITLE
Implement DELETE method for Notion calendar API

### DIFF
--- a/src/sandpiper/app/app.py
+++ b/src/sandpiper/app/app.py
@@ -1,5 +1,6 @@
 from sandpiper.app.message_dispatcher import MessageDispatcher
 from sandpiper.calendar.application.create_calendar_event import CreateCalendarEvent
+from sandpiper.calendar.application.delete_calendar_events import DeleteCalendarEvents
 from sandpiper.calendar.infrastructure.notion_calendar_repository import NotionCalendarRepository
 from sandpiper.perform.application.complete_todo import CompleteTodo
 from sandpiper.perform.application.handle_todo_started import HandleTodoStarted
@@ -35,6 +36,7 @@ class SandPiperApp:
         start_todo: StartTodo,
         complete_todo: CompleteTodo,
         create_calendar_event: CreateCalendarEvent,
+        delete_calendar_events: DeleteCalendarEvents,
     ) -> None:
         self.create_todo = create_todo
         self.create_repeat_task = create_repeat_task
@@ -44,6 +46,7 @@ class SandPiperApp:
         self.start_todo = start_todo
         self.complete_todo = complete_todo
         self.create_calendar_event = create_calendar_event
+        self.delete_calendar_events = delete_calendar_events
 
 
 def bootstrap() -> SandPiperApp:
@@ -100,6 +103,9 @@ def bootstrap() -> SandPiperApp:
             dispatcher=dispatcher,
         ),
         create_calendar_event=CreateCalendarEvent(
+            calendar_repository=calendar_repository,
+        ),
+        delete_calendar_events=DeleteCalendarEvents(
             calendar_repository=calendar_repository,
         ),
     )

--- a/src/sandpiper/calendar/application/delete_calendar_events.py
+++ b/src/sandpiper/calendar/application/delete_calendar_events.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from datetime import date
+
+from sandpiper.calendar.domain.calendar_repository import CalendarRepository
+
+
+@dataclass
+class DeleteCalendarEventsRequest:
+    target_date: date
+
+
+@dataclass
+class DeleteCalendarEventsResult:
+    deleted_count: int
+
+
+@dataclass
+class DeleteCalendarEvents:
+    _calendar_repository: CalendarRepository
+
+    def __init__(self, calendar_repository: CalendarRepository) -> None:
+        self._calendar_repository = calendar_repository
+
+    def execute(self, request: DeleteCalendarEventsRequest) -> DeleteCalendarEventsResult:
+        deleted_count = self._calendar_repository.delete_events_by_date(request.target_date)
+        return DeleteCalendarEventsResult(deleted_count=deleted_count)

--- a/src/sandpiper/calendar/domain/calendar_repository.py
+++ b/src/sandpiper/calendar/domain/calendar_repository.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import date
 
 from sandpiper.calendar.domain.calendar_event import CalendarEvent, InsertedCalendarEvent
 
@@ -6,4 +7,16 @@ from sandpiper.calendar.domain.calendar_event import CalendarEvent, InsertedCale
 class CalendarRepository(ABC):
     @abstractmethod
     def create(self, event: CalendarEvent) -> InsertedCalendarEvent:
+        pass
+
+    @abstractmethod
+    def delete_events_by_date(self, target_date: date) -> int:
+        """指定された日付のイベントを削除する
+
+        Args:
+            target_date: 削除対象の日付
+
+        Returns:
+            削除されたイベントの数
+        """
         pass

--- a/tests/test_calendar_api.py
+++ b/tests/test_calendar_api.py
@@ -5,8 +5,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from sandpiper.calendar.application.delete_calendar_events import DeleteCalendarEventsResult
 from sandpiper.calendar.domain.calendar_event import EventCategory, InsertedCalendarEvent
-from sandpiper.routers.notion import CreateCalendarEventApiRequest, router
+from sandpiper.routers.notion import router
 
 
 @pytest.fixture
@@ -14,7 +15,9 @@ def mock_sandpiper_app():
     """モックのSandPiperAppを作成"""
     mock_app = Mock()
     mock_create_calendar_event = Mock()
+    mock_delete_calendar_events = Mock()
     mock_app.create_calendar_event = mock_create_calendar_event
+    mock_app.delete_calendar_events = mock_delete_calendar_events
     return mock_app
 
 
@@ -22,15 +25,15 @@ def mock_sandpiper_app():
 def test_app(mock_sandpiper_app):
     """テスト用FastAPIアプリを作成"""
     app = FastAPI()
-    
+
     # 依存性注入を直接設定
     def get_test_app():
         return mock_sandpiper_app
-    
+
     # 依存性をオーバーライド
     from sandpiper.routers.dependency.deps import get_sandpiper_app
     app.dependency_overrides[get_sandpiper_app] = get_test_app
-    
+
     app.include_router(router, prefix="/api")
     return app
 
@@ -41,7 +44,7 @@ class TestCalendarAPI:
         # Arrange
         start_time = datetime(2024, 1, 15, 10, 0)
         end_time = datetime(2024, 1, 15, 11, 0)
-        
+
         expected_inserted_event = InsertedCalendarEvent(
             id="test-event-id",
             name="重要な会議",
@@ -50,18 +53,18 @@ class TestCalendarAPI:
             end_datetime=end_time,
         )
         mock_sandpiper_app.create_calendar_event.execute.return_value = expected_inserted_event
-        
+
         request_data = {
             "name": "重要な会議",
             "category": "仕事",
             "start_datetime": start_time.isoformat(),
             "end_datetime": end_time.isoformat(),
         }
-        
+
         # Act
         with TestClient(test_app) as client:
             response = client.post("/api/notion/calendar", json=request_data)
-        
+
         # Assert
         assert response.status_code == 200
         response_data = response.json()
@@ -70,7 +73,7 @@ class TestCalendarAPI:
         assert response_data["category"] == "仕事"
         assert response_data["start_datetime"] == start_time.isoformat()
         assert response_data["end_datetime"] == end_time.isoformat()
-        
+
         # サービスが正しく呼び出されたことを確認
         mock_sandpiper_app.create_calendar_event.execute.assert_called_once()
 
@@ -80,7 +83,7 @@ class TestCalendarAPI:
         # Arrange
         start_time = datetime(2024, 1, 15, 10, 0)
         end_time = datetime(2024, 1, 15, 11, 0)
-        
+
         category_enum = EventCategory(category)
         expected_inserted_event = InsertedCalendarEvent(
             id="test-event-id",
@@ -90,39 +93,110 @@ class TestCalendarAPI:
             end_datetime=end_time,
         )
         mock_sandpiper_app.create_calendar_event.execute.return_value = expected_inserted_event
-        
+
         request_data = {
             "name": "テストイベント",
             "category": category,
             "start_datetime": start_time.isoformat(),
             "end_datetime": end_time.isoformat(),
         }
-        
+
         # Act
         with TestClient(test_app) as client:
             response = client.post("/api/notion/calendar", json=request_data)
-        
+
         # Assert
         assert response.status_code == 200
         response_data = response.json()
         assert response_data["category"] == category
 
-    def test_create_calendar_event_invalid_category(self, test_app, mock_sandpiper_app):
+    def test_create_calendar_event_invalid_category(self, test_app, mock_sandpiper_app):  # noqa: ARG002
         """無効なカテゴリでのリクエストをテスト"""
         # Arrange
         start_time = datetime(2024, 1, 15, 10, 0)
         end_time = datetime(2024, 1, 15, 11, 0)
-        
+
         request_data = {
             "name": "テストイベント",
             "category": "無効なカテゴリ",
             "start_datetime": start_time.isoformat(),
             "end_datetime": end_time.isoformat(),
         }
-        
+
         # Act
         with TestClient(test_app) as client:
             response = client.post("/api/notion/calendar", json=request_data)
-        
+
         # Assert
         assert response.status_code == 422  # Validation Error
+
+    def test_delete_calendar_events_success(self, test_app, mock_sandpiper_app):
+        """カレンダーイベント削除APIが正常に動作することをテスト"""
+        # Arrange
+        mock_sandpiper_app.delete_calendar_events.execute.return_value = DeleteCalendarEventsResult(
+            deleted_count=3
+        )
+
+        # Act
+        with TestClient(test_app) as client:
+            response = client.delete("/api/notion/calendar/20240115")
+
+        # Assert
+        assert response.status_code == 200
+        response_data = response.json()
+        assert response_data["deleted_count"] == 3
+        assert response_data["target_date"] == "20240115"
+
+        # サービスが正しく呼び出されたことを確認
+        mock_sandpiper_app.delete_calendar_events.execute.assert_called_once()
+        call_args = mock_sandpiper_app.delete_calendar_events.execute.call_args[0][0]
+        assert call_args.target_date.year == 2024
+        assert call_args.target_date.month == 1
+        assert call_args.target_date.day == 15
+
+    def test_delete_calendar_events_invalid_date_format(self, test_app, mock_sandpiper_app):  # noqa: ARG002
+        """無効な日付形式でのリクエストをテスト"""
+        # Act
+        with TestClient(test_app) as client:
+            response = client.delete("/api/notion/calendar/2024-01-15")
+
+        # Assert
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "Invalid date format" in response_data["detail"]
+
+    def test_delete_calendar_events_invalid_date(self, test_app, mock_sandpiper_app):  # noqa: ARG002
+        """存在しない日付でのリクエストをテスト"""
+        # Act
+        with TestClient(test_app) as client:
+            response = client.delete("/api/notion/calendar/20241332")  # 13月32日
+
+        # Assert
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "Invalid date format" in response_data["detail"]
+
+    @pytest.mark.parametrize("date_str,expected_year,expected_month,expected_day", [
+        ("20240101", 2024, 1, 1),
+        ("20241231", 2024, 12, 31),
+        ("20250228", 2025, 2, 28),
+    ])
+    def test_delete_calendar_events_various_dates(
+        self, test_app, mock_sandpiper_app, date_str, expected_year, expected_month, expected_day
+    ):
+        """様々な日付形式でのリクエストをテスト"""
+        # Arrange
+        mock_sandpiper_app.delete_calendar_events.execute.return_value = DeleteCalendarEventsResult(
+            deleted_count=1
+        )
+
+        # Act
+        with TestClient(test_app) as client:
+            response = client.delete(f"/api/notion/calendar/{date_str}")
+
+        # Assert
+        assert response.status_code == 200
+        call_args = mock_sandpiper_app.delete_calendar_events.execute.call_args[0][0]
+        assert call_args.target_date.year == expected_year
+        assert call_args.target_date.month == expected_month
+        assert call_args.target_date.day == expected_day

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -1414,7 +1414,7 @@ wheels = [
 
 [[package]]
 name = "sandpiper"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
- DELETE /api/notion/calendar/{YYYYMMDD} エンドポイントを追加
- CalendarRepositoryにdelete_events_by_dateメソッドを追加
- NotionCalendarRepositoryに日付指定削除機能を実装
- DeleteCalendarEventsユースケースを作成
- SandPiperAppに新ユースケースを統合
- APIテストを追加（正常系・異常系・パラメータ化テスト）

指定された日付(YYYYMMDD形式)のカレンダーイベントを
Notionデータベースから検索・削除し、削除件数を返却します。

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
