### PR TITLE
feat: Fix todo list creation time logic and add repeat task

### DIFF
--- a/src/sandpiper/app/app.py
+++ b/src/sandpiper/app/app.py
@@ -97,13 +97,20 @@ def bootstrap() -> SandPiperApp:
         project_task_query=project_task_query,
         todo_repository=plan_notion_todo_repository,
     )
+    create_repeat_task = CreateRepeatTask(
+        routine_repository=routine_repository,
+        todo_repository=plan_notion_todo_repository,
+    )
 
     # Create special todo handler and register handlers
     handle_special_todo = HandleSpecialTodo(
         todo_repository=perform_notion_todo_repository,
     )
     handle_special_todo.register_handler(
-        CreateTomorrowTodoListHandler(create_repeat_project_task=create_repeat_project_task)
+        CreateTomorrowTodoListHandler(
+            create_repeat_project_task=create_repeat_project_task,
+            create_repeat_task=create_repeat_task,
+        )
     )
 
     return SandPiperApp(
@@ -117,10 +124,7 @@ def bootstrap() -> SandPiperApp:
         create_project_task=CreateProjectTask(
             project_task_repository=project_task_repository,
         ),
-        create_repeat_task=CreateRepeatTask(
-            routine_repository=routine_repository,
-            todo_repository=plan_notion_todo_repository,
-        ),
+        create_repeat_task=create_repeat_task,
         create_repeat_project_task=create_repeat_project_task,
         get_todo_log=GetTodoLog(
             todo_query=todo_query,

--- a/src/sandpiper/app/handlers/create_tomorrow_todo_list_handler.py
+++ b/src/sandpiper/app/handlers/create_tomorrow_todo_list_handler.py
@@ -2,32 +2,78 @@
 
 「明日のTODOリストを作成」というタイトルのTODOに対して、
 プロジェクトタスクから明日のTODOリストを自動生成します。
+
+日本時間の18:00〜23:59に実行された場合は「明日」のTODOとして作成し、
+00:00〜17:59に実行された場合は「今日」のTODOとして作成します。
 """
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
 
 from sandpiper.app.handlers.special_todo_handler import (
     HandleSpecialTodoResult,
     SpecialTodoHandler,
 )
 from sandpiper.plan.application.create_repeat_project_task import CreateRepeatProjectTask
+from sandpiper.plan.application.create_repeat_task import CreateRepeatTask
+
+JST = ZoneInfo("Asia/Tokyo")
+
+
+def _should_create_for_tomorrow() -> bool:
+    """日本時間の現在時刻から、明日のTODOを作成すべきかを判定する
+
+    18:00〜23:59の場合は明日のTODO、それ以外は今日のTODOを作成する
+
+    Returns:
+        bool: 明日のTODOを作成すべき場合True
+    """
+    now_jst = datetime.now(JST)
+    return 18 <= now_jst.hour <= 23
+
+
+def _get_basis_date() -> date:
+    """CreateRepeatTask用の基準日を取得する
+
+    18:00〜23:59の場合は明日の日付、それ以外は今日の日付を返す
+
+    Returns:
+        date: 基準日
+    """
+    now_jst = datetime.now(JST)
+    if 18 <= now_jst.hour <= 23:
+        # 明日の日付を返す
+        from datetime import timedelta
+
+        return (now_jst + timedelta(days=1)).date()
+    return now_jst.date()
 
 
 class CreateTomorrowTodoListHandler(SpecialTodoHandler):
     """明日のTODOリストを作成するハンドラー
 
     「明日のTODOリストを作成」というタイトルのTODOが処理されると、
-    CreateRepeatProjectTaskユースケースを実行して、
-    プロジェクトタスクから明日のTODOを自動生成します。
+    CreateRepeatProjectTaskとCreateRepeatTaskユースケースを実行して、
+    プロジェクトタスクとルーチンタスクからTODOを自動生成します。
+
+    日本時間18:00〜23:59は明日のTODO、00:00〜17:59は今日のTODOとして作成します。
     """
 
     TARGET_TITLE = "明日のTODOリストを作成"
 
-    def __init__(self, create_repeat_project_task: CreateRepeatProjectTask) -> None:
+    def __init__(
+        self,
+        create_repeat_project_task: CreateRepeatProjectTask,
+        create_repeat_task: CreateRepeatTask,
+    ) -> None:
         """初期化
 
         Args:
             create_repeat_project_task: プロジェクトタスクからTODOを作成するユースケース
+            create_repeat_task: ルーチンタスクからTODOを作成するユースケース
         """
         self._create_repeat_project_task = create_repeat_project_task
+        self._create_repeat_task = create_repeat_task
 
     @property
     def handler_name(self) -> str:
@@ -38,7 +84,10 @@ class CreateTomorrowTodoListHandler(SpecialTodoHandler):
         return self.TARGET_TITLE
 
     def handle(self, page_id: str, title: str) -> HandleSpecialTodoResult:
-        """明日のTODOリストを作成する
+        """TODOリストを作成する
+
+        日本時間18:00〜23:59は明日のTODO、00:00〜17:59は今日のTODOとして作成。
+        プロジェクトタスクとルーチンタスクの両方を処理します。
 
         Args:
             page_id: NotionのページID
@@ -48,15 +97,24 @@ class CreateTomorrowTodoListHandler(SpecialTodoHandler):
             HandleSpecialTodoResult: 処理結果
         """
         try:
-            self._create_repeat_project_task.execute(is_tomorrow=True)
+            is_tomorrow = _should_create_for_tomorrow()
+            basis_date = _get_basis_date()
+            target_day = "明日" if is_tomorrow else "今日"
+
+            # プロジェクトタスクからTODOを作成
+            self._create_repeat_project_task.execute(is_tomorrow=is_tomorrow)
+
+            # ルーチンタスクからTODOを作成
+            self._create_repeat_task.execute(basis_date=basis_date)
+
             return self._success_result(
                 page_id=page_id,
                 title=title,
-                message="明日のTODOリストを作成しました",
+                message=f"{target_day}のTODOリストを作成しました",
             )
         except Exception as e:
             return self._failure_result(
                 page_id=page_id,
                 title=title,
-                message=f"明日のTODOリスト作成に失敗しました: {e}",
+                message=f"TODOリスト作成に失敗しました: {e}",
             )


### PR DESCRIPTION
- 日本時間18:00〜23:59は明日のTODO、00:00〜17:59は今日のTODOとして作成
- 深夜帯の実行時に正しい日付でTODOを作成するよう修正
- CreateRepeatTaskも実行してルーチンタスクも自動生成するよう追加
- bootstrap()でCreateRepeatTaskインスタンスを共有するようリファクタリング

🚀 Generated with [Claude Code](https://claude.ai/code)

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
