### PR TITLE
feat: Create TodoIsToday property and refactor CreateRepeatTask

### DIFF
--- a/src/sandpiper/app/app.py
+++ b/src/sandpiper/app/app.py
@@ -20,6 +20,7 @@ from sandpiper.plan.infrastructure.notion_project_task_repository import NotionP
 from sandpiper.plan.infrastructure.notion_routine_repository import NotionRoutineRepository
 from sandpiper.plan.infrastructure.notion_todo_repository import NotionTodoRepository as PlanNotionTodoRepository
 from sandpiper.plan.query.project_task_query import NotionProjectTaskQuery
+from sandpiper.plan.query.todo_query import NotionTodoQuery as PlanNotionTodoQuery
 from sandpiper.recipe.application.create_recipe import CreateRecipe
 from sandpiper.recipe.infrastructure.notion_recipe_repository import NotionRecipeRepository
 from sandpiper.recipe.infrastructure.notion_shopping_repository import NotionShoppingRepository
@@ -108,9 +109,11 @@ def bootstrap() -> SandPiperApp:
         project_task_query=project_task_query,
         todo_repository=plan_notion_todo_repository,
     )
+    plan_todo_query = PlanNotionTodoQuery()
     create_repeat_task = CreateRepeatTask(
         routine_repository=routine_repository,
         todo_repository=plan_notion_todo_repository,
+        todo_query=plan_todo_query,
     )
 
     # Create special todo handler and register handlers

--- a/src/sandpiper/plan/application/create_repeat_task.py
+++ b/src/sandpiper/plan/application/create_repeat_task.py
@@ -4,22 +4,27 @@ from datetime import date
 from sandpiper.plan.domain.routine_repository import RoutineRepository
 from sandpiper.plan.domain.todo import ToDo, ToDoKind
 from sandpiper.plan.domain.todo_repository import TodoRepository
+from sandpiper.plan.query.todo_query import TodoQuery
 
 
 @dataclass
 class CreateRepeatTask:
     routine_repository: RoutineRepository
     todo_repository: TodoRepository
+    todo_query: TodoQuery
 
-    def __init__(self, routine_repository: RoutineRepository, todo_repository: TodoRepository) -> None:
+    def __init__(
+        self, routine_repository: RoutineRepository, todo_repository: TodoRepository, todo_query: TodoQuery
+    ) -> None:
         self.routine_repository = routine_repository
         self.todo_repository = todo_repository
+        self.todo_query = todo_query
 
     def execute(self, basis_date: date) -> None:
         # Create the main task
         print("Creating repeat tasks...")
         routines = self.routine_repository.fetch()
-        todos: list[ToDo] = self.todo_repository.fetch()
+        todos: list[ToDo] = self.todo_query.fetch_todos_not_is_today()
         todo_names = [todo.title for todo in todos]
         for routine in routines:
             # 今日の日付以前のルーチンタスクのみ処理する

--- a/src/sandpiper/plan/query/__init__.py
+++ b/src/sandpiper/plan/query/__init__.py
@@ -2,5 +2,6 @@
 
 from sandpiper.plan.query.project_task_dto import ProjectTaskDto
 from sandpiper.plan.query.project_task_query import NotionProjectTaskQuery, ProjectTaskQuery
+from sandpiper.plan.query.todo_query import NotionTodoQuery, TodoQuery
 
-__all__ = ["NotionProjectTaskQuery", "ProjectTaskDto", "ProjectTaskQuery"]
+__all__ = ["NotionProjectTaskQuery", "NotionTodoQuery", "ProjectTaskDto", "ProjectTaskQuery", "TodoQuery"]

--- a/src/sandpiper/plan/query/todo_query.py
+++ b/src/sandpiper/plan/query/todo_query.py
@@ -1,0 +1,49 @@
+from typing import Protocol
+
+from lotion import Lotion  # type: ignore[import-untyped]
+
+from sandpiper.plan.domain.todo import ToDo, ToDoKind
+from sandpiper.shared.notion.database_config import DatabaseId
+from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
+from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
+
+
+class TodoQuery(Protocol):
+    def fetch_todos_not_is_today(self) -> list[ToDo]:
+        """'今日中にやる'が無効かつTODOステータスのTODO一覧を取得する"""
+        ...
+
+
+class NotionTodoQuery(TodoQuery):
+    def __init__(self) -> None:
+        self.client = Lotion.get_instance()
+
+    def fetch_todos_not_is_today(self) -> list[ToDo]:
+        """'今日中にやる'が無効かつTODOステータスのTODO一覧を取得する"""
+        items = self.client.retrieve_database(DatabaseId.TODO)
+        result: list[ToDo] = []
+        for item in items:
+            status = ToDoStatusEnum(item.get_status("ステータス").status_name)
+            if status != ToDoStatusEnum.TODO:
+                continue
+
+            is_today = item.get_checkbox("今日中にやる").checked
+            if is_today:
+                continue
+
+            section_select = item.get_select("セクション")
+            kind_select = item.get_select("タスク種別")
+            project_relations = item.get_relation("プロジェクト").id_list
+            project_task_relations = item.get_relation("プロジェクトタスク").id_list
+            execution_time = item.get_number("実行時間").number
+
+            todo = ToDo(
+                title=item.get_title_text(),
+                kind=ToDoKind(kind_select.selected_name) if kind_select.selected_name else None,
+                section=TaskChuteSection(section_select.selected_name) if section_select.selected_name else None,
+                project_page_id=project_relations[0] if project_relations else None,
+                project_task_page_id=project_task_relations[0] if project_task_relations else None,
+                execution_time=int(execution_time) if execution_time else None,
+            )
+            result.append(todo)
+        return result

--- a/src/sandpiper/shared/notion/notion_props.py
+++ b/src/sandpiper/shared/notion/notion_props.py
@@ -1,5 +1,14 @@
 from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Date, Number, Relation, Select, Status, Title, Url  # type: ignore[import-untyped]
+from lotion.properties import (  # type: ignore[import-untyped]
+    Checkbox,
+    Date,
+    Number,
+    Relation,
+    Select,
+    Status,
+    Title,
+    Url,
+)
 
 # ToDo関連のプロパティ
 
@@ -16,6 +25,11 @@ class TodoStatus(Status):  # type: ignore[misc]
 
 @notion_prop("セクション")
 class TodoSection(Select):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("今日中にやる")
+class TodoIsTodayProp(Checkbox):  # type: ignore[misc]
     ...
 
 


### PR DESCRIPTION
- Add TodoIsTodayProp class to check "今日中にやる" checkbox
- Create PlanTodoQuery to fetch TODOs where "今日中にやる" is unchecked
- Update CreateRepeatTask to use TodoQuery for duplicate checking

This change ensures that repeat tasks are only checked for duplicates against TODOs that don't have the "今日中にやる" flag enabled.

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
