### PR TITLE
feat: Add auto-title property to Inbox database

### DIFF
--- a/src/sandpiper/clips/application/create_clip.py
+++ b/src/sandpiper/clips/application/create_clip.py
@@ -63,7 +63,11 @@ class CreateClip:
             title = fetch_page_title(request.url) or DEFAULT_TITLE
 
         inbox_type = InboxType.from_url(request.url)
-        clip = Clip(title=title, url=request.url, inbox_type=inbox_type)
+
+        # 種類がVIDEO (Youtube)またはタイトルが取得できなかった場合、自動取得フラグを立てる
+        auto_fetch_title = inbox_type == InboxType.VIDEO or title == DEFAULT_TITLE
+
+        clip = Clip(title=title, url=request.url, inbox_type=inbox_type, auto_fetch_title=auto_fetch_title)
         inserted_clip = self._clips_repository.save(clip)
         print(f"Created Clip: {inserted_clip}")
         return inserted_clip

--- a/src/sandpiper/clips/domain/clip.py
+++ b/src/sandpiper/clips/domain/clip.py
@@ -10,6 +10,7 @@ class Clip:
     title: str
     url: str
     inbox_type: InboxType
+    auto_fetch_title: bool = False
 
 
 @dataclass(frozen=True)
@@ -20,3 +21,4 @@ class InsertedClip:
     title: str
     url: str
     inbox_type: InboxType
+    auto_fetch_title: bool = False

--- a/src/sandpiper/clips/infrastructure/notion_clips_repository.py
+++ b/src/sandpiper/clips/infrastructure/notion_clips_repository.py
@@ -3,7 +3,7 @@ from lotion import BasePage, Lotion, notion_database  # type: ignore[import-unty
 from sandpiper.clips.domain.clip import Clip, InsertedClip
 from sandpiper.clips.domain.clips_repository import ClipsRepository
 from sandpiper.shared.notion.databases import clips as clips_db
-from sandpiper.shared.notion.databases.clips import ClipsName, ClipsTypeProp, ClipsUrl
+from sandpiper.shared.notion.databases.clips import ClipsAutoFetchTitle, ClipsName, ClipsTypeProp, ClipsUrl
 
 
 @notion_database(clips_db.DATABASE_ID)
@@ -11,6 +11,7 @@ class ClipsPage(BasePage):  # type: ignore[misc]
     name: ClipsName
     url: ClipsUrl | None = None
     inbox_type: ClipsTypeProp | None = None
+    auto_fetch_title: ClipsAutoFetchTitle | None = None
 
     @staticmethod
     def generate(clip: Clip) -> "ClipsPage":
@@ -18,6 +19,7 @@ class ClipsPage(BasePage):  # type: ignore[misc]
             ClipsName.from_plain_text(clip.title),
             ClipsUrl.from_url(clip.url),
             ClipsTypeProp.from_name(clip.inbox_type.value),
+            ClipsAutoFetchTitle.true() if clip.auto_fetch_title else ClipsAutoFetchTitle.false(),
         ]
         return ClipsPage.create(properties=properties)  # type: ignore[no-any-return]
 
@@ -34,4 +36,5 @@ class NotionClipsRepository(ClipsRepository):
             title=clip.title,
             url=clip.url,
             inbox_type=clip.inbox_type,
+            auto_fetch_title=clip.auto_fetch_title,
         )

--- a/src/sandpiper/shared/notion/databases/__init__.py
+++ b/src/sandpiper/shared/notion/databases/__init__.py
@@ -22,6 +22,7 @@ from sandpiper.shared.notion.databases.calendar import (
     CalendarEventStartDate,
 )
 from sandpiper.shared.notion.databases.clips import (
+    ClipsAutoFetchTitle,
     ClipsName,
     ClipsTypeProp,
     ClipsUrl,
@@ -95,6 +96,7 @@ __all__ = [
     "CalendarEventEndDate",
     "CalendarEventName",
     "CalendarEventStartDate",
+    "ClipsAutoFetchTitle",
     "ClipsName",
     "ClipsTypeProp",
     "ClipsUrl",

--- a/src/sandpiper/shared/notion/databases/clips.py
+++ b/src/sandpiper/shared/notion/databases/clips.py
@@ -1,5 +1,5 @@
 from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Select, Title, Url  # type: ignore[import-untyped]
+from lotion.properties import Checkbox, Select, Title, Url  # type: ignore[import-untyped]
 
 DATABASE_ID = "2e66567a3bbf80aa8c83f113aa101d44"  # TODO: 実際のNotion Clips Database IDに置き換えてください
 
@@ -16,4 +16,9 @@ class ClipsUrl(Url):  # type: ignore[misc]
 
 @notion_prop("種類")
 class ClipsTypeProp(Select):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("タイトル自動取得")
+class ClipsAutoFetchTitle(Checkbox):  # type: ignore[misc]
     ...


### PR DESCRIPTION
Add a checkbox property to mark clips that need automatic title fetching. The flag is enabled when:
- The clip type is VIDEO (YouTube)
- The title could not be fetched (falls back to default)

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
