### PR TITLE
feat: Add CLI command for someday list items

### DIFF
--- a/src/sandpiper/app/app.py
+++ b/src/sandpiper/app/app.py
@@ -15,6 +15,7 @@ from sandpiper.plan.application.create_project import CreateProject
 from sandpiper.plan.application.create_project_task import CreateProjectTask
 from sandpiper.plan.application.create_repeat_project_task import CreateRepeatProjectTask
 from sandpiper.plan.application.create_repeat_task import CreateRepeatTask
+from sandpiper.plan.application.create_someday_item import CreateSomedayItem
 from sandpiper.plan.application.create_tasks_by_someday_list import CreateTasksBySomedayList
 from sandpiper.plan.application.create_todo import CreateToDo
 from sandpiper.plan.application.handle_completed_task import HandleCompletedTask
@@ -64,6 +65,7 @@ class SandPiperApp:
         sync_jira_to_project: SyncJiraToProject,
         archive_deleted_pages: ArchiveDeletedPages,
         create_clip: CreateClip,
+        create_someday_item: CreateSomedayItem,
     ) -> None:
         self.create_todo = create_todo
         self.create_project = create_project
@@ -82,6 +84,7 @@ class SandPiperApp:
         self.sync_jira_to_project = sync_jira_to_project
         self.archive_deleted_pages = archive_deleted_pages
         self.create_clip = create_clip
+        self.create_someday_item = create_someday_item
 
 
 def bootstrap() -> SandPiperApp:
@@ -200,5 +203,8 @@ def bootstrap() -> SandPiperApp:
         archive_deleted_pages=ArchiveDeletedPages(),
         create_clip=CreateClip(
             clips_repository=NotionClipsRepository(),
+        ),
+        create_someday_item=CreateSomedayItem(
+            someday_repository=someday_repository,
         ),
     )

--- a/src/sandpiper/main.py
+++ b/src/sandpiper/main.py
@@ -9,6 +9,7 @@ from rich.panel import Panel
 
 from sandpiper.app.app import bootstrap
 from sandpiper.plan.application.create_project_task import CreateProjectTaskRequest
+from sandpiper.plan.application.create_someday_item import CreateSomedayItemRequest
 from sandpiper.plan.application.create_todo import CreateNewToDoRequest
 from sandpiper.recipe.application.create_recipe import CreateRecipeRequest, IngredientRequest
 from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
@@ -55,6 +56,18 @@ def create_todo(title: str, start: bool = typer.Option(False, help="タスクを
         ),
         enableStart=start,
     )
+
+
+@app.command()
+def create_someday(title: str = typer.Argument(..., help="サムデイアイテムのタイトル")) -> None:
+    """サムデイリストにアイテムを追加します
+
+    タイミングは自動的に「明日」が設定されます。
+    """
+    result = sandpiper_app.create_someday_item.execute(
+        request=CreateSomedayItemRequest(title=title),
+    )
+    console.print(f"[green]サムデイアイテムを作成しました: {result.title} (タイミング: {result.timing})[/green]")
 
 
 @app.command()

--- a/src/sandpiper/plan/application/create_someday_item.py
+++ b/src/sandpiper/plan/application/create_someday_item.py
@@ -1,0 +1,53 @@
+"""サムデイリストにアイテムを追加するユースケース"""
+
+from dataclasses import dataclass
+
+from sandpiper.plan.domain.someday_item import SomedayItem, SomedayTiming
+from sandpiper.plan.domain.someday_repository import SomedayRepository
+
+
+@dataclass
+class CreateSomedayItemRequest:
+    """サムデイアイテム作成リクエスト"""
+
+    title: str
+
+
+@dataclass
+class CreateSomedayItemResult:
+    """サムデイアイテム作成結果"""
+
+    id: str
+    title: str
+    timing: str
+
+
+class CreateSomedayItem:
+    """サムデイリストにアイテムを追加するユースケース
+
+    タイミングは必ず「明日」が設定されます。
+    """
+
+    def __init__(self, someday_repository: SomedayRepository) -> None:
+        self.someday_repository = someday_repository
+
+    def execute(self, request: CreateSomedayItemRequest) -> CreateSomedayItemResult:
+        """サムデイアイテムを作成する
+
+        Args:
+            request: サムデイアイテム作成リクエスト
+
+        Returns:
+            作成されたサムデイアイテムの情報
+        """
+        item = SomedayItem.create(
+            title=request.title,
+            timing=SomedayTiming.TOMORROW,
+        )
+        saved_item = self.someday_repository.save(item)
+
+        return CreateSomedayItemResult(
+            id=saved_item.id,
+            title=saved_item.title,
+            timing=saved_item.timing.value,
+        )

--- a/tests/plan/application/test_create_someday_item.py
+++ b/tests/plan/application/test_create_someday_item.py
@@ -1,0 +1,112 @@
+from unittest.mock import Mock
+
+from sandpiper.plan.application.create_someday_item import (
+    CreateSomedayItem,
+    CreateSomedayItemRequest,
+    CreateSomedayItemResult,
+)
+from sandpiper.plan.domain.someday_item import SomedayItem, SomedayTiming
+from sandpiper.plan.domain.someday_repository import SomedayRepository
+
+
+class TestCreateSomedayItem:
+    def setup_method(self):
+        self.mock_someday_repository = Mock(spec=SomedayRepository)
+        self.service = CreateSomedayItem(
+            someday_repository=self.mock_someday_repository,
+        )
+
+    def test_execute_creates_item_with_tomorrow_timing(self):
+        """アイテムがタイミング「明日」で作成されることを確認"""
+        # Arrange
+        saved_item = SomedayItem(
+            id="created-item-1",
+            title="テストアイテム",
+            timing=SomedayTiming.TOMORROW,
+            do_tomorrow=False,
+            is_deleted=False,
+        )
+        self.mock_someday_repository.save.return_value = saved_item
+
+        request = CreateSomedayItemRequest(title="テストアイテム")
+
+        # Act
+        result = self.service.execute(request)
+
+        # Assert
+        assert result.id == "created-item-1"
+        assert result.title == "テストアイテム"
+        assert result.timing == "明日"
+
+        # saveが呼ばれたことを確認
+        self.mock_someday_repository.save.assert_called_once()
+        saved_arg = self.mock_someday_repository.save.call_args[0][0]
+        assert isinstance(saved_arg, SomedayItem)
+        assert saved_arg.title == "テストアイテム"
+        assert saved_arg.timing == SomedayTiming.TOMORROW
+
+    def test_execute_always_uses_tomorrow_timing(self):
+        """タイミングが常に「明日」になることを確認"""
+        # Arrange
+        saved_item = SomedayItem(
+            id="item-2",
+            title="別のアイテム",
+            timing=SomedayTiming.TOMORROW,
+        )
+        self.mock_someday_repository.save.return_value = saved_item
+
+        request = CreateSomedayItemRequest(title="別のアイテム")
+
+        # Act
+        self.service.execute(request)
+
+        # Assert
+        saved_arg = self.mock_someday_repository.save.call_args[0][0]
+        assert saved_arg.timing == SomedayTiming.TOMORROW
+
+    def test_execute_returns_correct_result(self):
+        """正しい結果オブジェクトが返されることを確認"""
+        # Arrange
+        saved_item = SomedayItem(
+            id="result-item",
+            title="結果確認用アイテム",
+            timing=SomedayTiming.TOMORROW,
+        )
+        self.mock_someday_repository.save.return_value = saved_item
+
+        request = CreateSomedayItemRequest(title="結果確認用アイテム")
+
+        # Act
+        result = self.service.execute(request)
+
+        # Assert
+        assert isinstance(result, CreateSomedayItemResult)
+        assert result.id == "result-item"
+        assert result.title == "結果確認用アイテム"
+        assert result.timing == "明日"
+
+
+class TestCreateSomedayItemRequest:
+    def test_request_creation(self):
+        """リクエストオブジェクトの作成をテスト"""
+        # Act
+        request = CreateSomedayItemRequest(title="テストタイトル")
+
+        # Assert
+        assert request.title == "テストタイトル"
+
+
+class TestCreateSomedayItemResult:
+    def test_result_creation(self):
+        """結果オブジェクトの作成をテスト"""
+        # Act
+        result = CreateSomedayItemResult(
+            id="test-id",
+            title="テストタイトル",
+            timing="明日",
+        )
+
+        # Assert
+        assert result.id == "test-id"
+        assert result.title == "テストタイトル"
+        assert result.timing == "明日"


### PR DESCRIPTION
Add a new CLI command `create-someday` that allows users to add items to the someday list with the timing automatically set to "明日" (tomorrow).

- CreateSomedayItem application service with fixed TOMORROW timing
- CLI command with title argument
- Unit tests for the new use case

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
