### PR TITLE
feat: Add TODO to next section in list

### DIFF
--- a/src/sandpiper/main.py
+++ b/src/sandpiper/main.py
@@ -11,7 +11,9 @@ from sandpiper.app.app import bootstrap
 from sandpiper.plan.application.create_project_task import CreateProjectTaskRequest
 from sandpiper.plan.application.create_someday_item import CreateSomedayItemRequest
 from sandpiper.plan.application.create_todo import CreateNewToDoRequest
+from sandpiper.plan.domain.todo import ToDoKind
 from sandpiper.recipe.application.create_recipe import CreateRecipeRequest, IngredientRequest
+from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
 from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
 
 from . import __version__
@@ -53,6 +55,29 @@ def create_todo(title: str, start: bool = typer.Option(False, help="タスクを
     sandpiper_app.create_todo.execute(
         request=CreateNewToDoRequest(
             title=title,
+        ),
+        enableStart=start,
+    )
+
+
+@app.command()
+def create_todo_next_section(
+    title: str = typer.Argument(..., help="ToDoのタイトル"),
+    start: bool = typer.Option(False, help="タスクをすぐに開始するかどうか"),
+) -> None:
+    """現時刻の次のセクションに単発ToDoを作成します
+
+    現在時刻に該当するセクションの次のセクションにタスクを追加します。
+    例: 現在が10:00-13:00 (B) の場合、13:00-17:00 (C) にタスクが作成されます。
+    """
+    current_section = TaskChuteSection.new()
+    next_section = current_section.next()
+    console.print(f"[dim]現在のセクション: {current_section.value} → 次のセクション: {next_section.value}[/dim]")
+    sandpiper_app.create_todo.execute(
+        request=CreateNewToDoRequest(
+            title=title,
+            kind=ToDoKind.SINGLE,
+            section=next_section,
         ),
         enableStart=start,
     )

--- a/src/sandpiper/shared/valueobject/task_chute_section.py
+++ b/src/sandpiper/shared/valueobject/task_chute_section.py
@@ -13,6 +13,13 @@ class TaskChuteSection(Enum):
     F_22_24 = "F_22_24"
     G_24_07 = "G_24_07"
 
+    def next(self) -> "TaskChuteSection":
+        """次のセクションを返す"""
+        sections = list(TaskChuteSection)
+        current_index = sections.index(self)
+        next_index = (current_index + 1) % len(sections)
+        return sections[next_index]
+
     @staticmethod
     def new(dt: datetime | None = None) -> "TaskChuteSection":
         """新しいセクションを返す"""

--- a/tests/shared/valueobject/test_task_chute_section.py
+++ b/tests/shared/valueobject/test_task_chute_section.py
@@ -88,3 +88,25 @@ class TestTaskChuteSection:
 
         assert TaskChuteSection.new(dt_23_59) == TaskChuteSection.F_22_24
         assert TaskChuteSection.new(dt_00_00) == TaskChuteSection.G_24_07
+
+    @pytest.mark.parametrize(
+        "current_section, expected_next",
+        [
+            (TaskChuteSection.A_07_10, TaskChuteSection.B_10_13),
+            (TaskChuteSection.B_10_13, TaskChuteSection.C_13_17),
+            (TaskChuteSection.C_13_17, TaskChuteSection.D_17_19),
+            (TaskChuteSection.D_17_19, TaskChuteSection.E_19_22),
+            (TaskChuteSection.E_19_22, TaskChuteSection.F_22_24),
+            (TaskChuteSection.F_22_24, TaskChuteSection.G_24_07),
+            (TaskChuteSection.G_24_07, TaskChuteSection.A_07_10),  # 循環
+        ],
+    )
+    def test_next_section(self, current_section: TaskChuteSection, expected_next: TaskChuteSection):
+        # 次のセクションが正しく取得できることを確認
+        assert current_section.next() == expected_next
+
+    def test_next_section_cycles_back_to_first(self):
+        # 最後のセクションから最初のセクションに循環することを確認
+        last_section = TaskChuteSection.G_24_07
+        first_section = TaskChuteSection.A_07_10
+        assert last_section.next() == first_section


### PR DESCRIPTION
…ime section

Add TaskChuteSection.next() method to get the next time section in sequence, and create-todo-next-section CLI command that creates a single todo in the next time section from the current time.

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
