### PR TITLE
feat: Add skincare todo creation after bathing completion

### DIFF
--- a/src/sandpiper/plan/domain/next_todo_rule.py
+++ b/src/sandpiper/plan/domain/next_todo_rule.py
@@ -31,5 +31,11 @@ def next_todo_rule(title: str) -> ToDo | None:
                 kind=ToDoKind.REPEAT,
                 section=TaskChuteSection.new(jst_now() + timedelta(minutes=60)),
             )
+        case "入浴":
+            return ToDo(
+                title="化粧水を塗る",
+                kind=ToDoKind.REPEAT,
+                section=TaskChuteSection.new(jst_now()),
+            )
         case _:
             return None

--- a/tests/plan/domain/test_next_todo_rule.py
+++ b/tests/plan/domain/test_next_todo_rule.py
@@ -75,6 +75,22 @@ class TestNextTodoRule:
         expected_section = TaskChuteSection.new(mock_now + timedelta(minutes=60))
         assert result.section == expected_section
 
+    @pytest.mark.parametrize("title", ["入浴"])
+    def test_入浴完了で化粧水を塗るが作成される(self, title: str):
+        # Arrange
+        mock_now = datetime(2024, 3, 20, 22, 0)
+
+        # Act
+        with patch("sandpiper.plan.domain.next_todo_rule.jst_now", return_value=mock_now):
+            result = next_todo_rule(title)
+
+        # Assert
+        assert result is not None
+        assert result.title == "化粧水を塗る"
+        assert result.kind == ToDoKind.REPEAT
+        expected_section = TaskChuteSection.new(mock_now)
+        assert result.section == expected_section
+
     @pytest.mark.parametrize("title", ["会議", "ミーティング", "その他のタスク", ""])
     def test_ルールに該当しないタイトルはNoneを返す(self, title: str):
         # Act


### PR DESCRIPTION
When the "入浴" (bathing) todo is completed, automatically create a
"化粧水を塗る" (apply lotion) todo for immediate execution.