### PR TITLE
feat: Add archive functionality for completed todos older than 7 days

### DIFF
--- a/src/sandpiper/app/app.py
+++ b/src/sandpiper/app/app.py
@@ -42,6 +42,7 @@ from sandpiper.shared.event.todo_completed import TodoCompleted
 from sandpiper.shared.event.todo_created import TodoCreated
 from sandpiper.shared.event.todo_started import TodoStarted
 from sandpiper.shared.infrastructure.archive_deleted_pages import ArchiveDeletedPages
+from sandpiper.shared.infrastructure.archive_old_todos import ArchiveOldTodos
 from sandpiper.shared.infrastructure.event_bus import EventBus
 from sandpiper.shared.infrastructure.github_client import GitHubClient
 from sandpiper.shared.infrastructure.notion_commentator import NotionCommentator
@@ -67,6 +68,7 @@ class SandPiperApp:
         create_recipe: CreateRecipe,
         sync_jira_to_project: SyncJiraToProject,
         archive_deleted_pages: ArchiveDeletedPages,
+        archive_old_todos: ArchiveOldTodos,
         create_clip: CreateClip,
         create_someday_item: CreateSomedayItem,
     ) -> None:
@@ -86,6 +88,7 @@ class SandPiperApp:
         self.create_recipe = create_recipe
         self.sync_jira_to_project = sync_jira_to_project
         self.archive_deleted_pages = archive_deleted_pages
+        self.archive_old_todos = archive_old_todos
         self.create_clip = create_clip
         self.create_someday_item = create_someday_item
 
@@ -212,6 +215,7 @@ def bootstrap() -> SandPiperApp:
             project_task_repository=project_task_repository,
         ),
         archive_deleted_pages=ArchiveDeletedPages(),
+        archive_old_todos=ArchiveOldTodos(),
         create_clip=CreateClip(
             clips_repository=NotionClipsRepository(),
         ),

--- a/src/sandpiper/shared/infrastructure/archive_old_todos.py
+++ b/src/sandpiper/shared/infrastructure/archive_old_todos.py
@@ -1,0 +1,155 @@
+"""完了して一定期間経過したTODOをアーカイブするサービス"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+
+from sandpiper.shared.notion.databases import todo as todo_db
+from sandpiper.shared.notion.databases import todo_archive as todo_archive_db
+from sandpiper.shared.notion.databases.todo_archive import (
+    TodoArchiveContext,
+    TodoArchiveExecutionTime,
+    TodoArchiveIsDeleted,
+    TodoArchiveIsTodayProp,
+    TodoArchiveKindProp,
+    TodoArchiveLogDate,
+    TodoArchiveName,
+    TodoArchiveProjectProp,
+    TodoArchiveProjectTaskProp,
+    TodoArchiveSection,
+    TodoArchiveSortOrder,
+    TodoArchiveStatus,
+)
+from sandpiper.shared.utils.date_utils import jst_now
+from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
+
+DEFAULT_ARCHIVE_DAYS = 7
+
+
+@notion_database(todo_archive_db.DATABASE_ID)
+class TodoArchivePage(BasePage):  # type: ignore[misc]
+    name: TodoArchiveName
+    status: TodoArchiveStatus
+
+
+@dataclass
+class ArchiveOldTodosResult:
+    """アーカイブ結果"""
+
+    archived_count: int
+    archived_titles: list[str]
+
+
+class ArchiveOldTodos:
+    """完了して一定期間経過したTODOをアーカイブするサービス
+
+    DONEステータスのTODOで、完了日時(log_end_datetime)から
+    指定日数(デフォルト7日)経過したものをアーカイブデータベースに移動します。
+    """
+
+    def __init__(
+        self,
+        archive_days: int = DEFAULT_ARCHIVE_DAYS,
+    ) -> None:
+        self.client = Lotion.get_instance()
+        self.archive_days = archive_days
+
+    def execute(self, dry_run: bool = False) -> ArchiveOldTodosResult:
+        """完了して一定期間経過したTODOをアーカイブする
+
+        Args:
+            dry_run: Trueの場合、実際のアーカイブは行わず対象のみを返す
+
+        Returns:
+            ArchiveOldTodosResult: アーカイブされた(または対象となる)TODOの件数とタイトル一覧
+        """
+        now = jst_now()
+        threshold_date = now - timedelta(days=self.archive_days)
+
+        pages = self.client.retrieve_database(todo_db.DATABASE_ID)
+
+        archived_count = 0
+        archived_titles: list[str] = []
+
+        for page in pages:
+            if not self._should_archive(page, threshold_date):
+                continue
+
+            title = page.get_title_text()
+
+            if not dry_run:
+                self._archive_page(page)
+                self.client.remove_page(page.id)
+
+            archived_count += 1
+            archived_titles.append(title)
+
+        return ArchiveOldTodosResult(
+            archived_count=archived_count,
+            archived_titles=archived_titles,
+        )
+
+    def _should_archive(self, page: BasePage, threshold_date: datetime) -> bool:
+        """ページがアーカイブ対象かどうかを判定"""
+        status = ToDoStatusEnum(page.get_status("ステータス").status_name)
+        if status != ToDoStatusEnum.DONE:
+            return False
+
+        perform_range = page.get_date("実施期間")
+        if perform_range.end is None:
+            return False
+
+        end_datetime = datetime.fromisoformat(perform_range.end)
+        return end_datetime < threshold_date
+
+    def _archive_page(self, page: BasePage) -> None:
+        """ページをアーカイブデータベースにコピー"""
+        properties = [
+            TodoArchiveName.from_plain_text(page.get_title_text()),
+            TodoArchiveStatus.from_status_name(page.get_status("ステータス").status_name),
+        ]
+
+        section = page.get_select("セクション")
+        if section.selected_name:
+            properties.append(TodoArchiveSection.from_name(section.selected_name))
+
+        is_today = page.get_checkbox("今日中にやる")
+        properties.append(TodoArchiveIsTodayProp.true() if is_today.checked else TodoArchiveIsTodayProp.false())
+
+        perform_range = page.get_date("実施期間")
+        if perform_range.start or perform_range.end:
+            start_dt = datetime.fromisoformat(perform_range.start) if perform_range.start else None
+            end_dt = datetime.fromisoformat(perform_range.end) if perform_range.end else None
+            properties.append(TodoArchiveLogDate.from_range(start=start_dt, end=end_dt))
+
+        kind = page.get_select("タスク種別")
+        if kind.selected_name:
+            properties.append(TodoArchiveKindProp.from_name(kind.selected_name))
+
+        project = page.get_relation("プロジェクト")
+        if project.id_list:
+            properties.append(TodoArchiveProjectProp.from_id(project.id_list[0]))
+
+        project_task = page.get_relation("プロジェクトタスク")
+        if project_task.id_list:
+            properties.append(TodoArchiveProjectTaskProp.from_id(project_task.id_list[0]))
+
+        execution_time = page.get_number("実行時間")
+        if execution_time.number is not None:
+            properties.append(TodoArchiveExecutionTime.from_num(int(execution_time.number)))
+
+        is_deleted = page.get_checkbox("論理削除")
+        properties.append(TodoArchiveIsDeleted.true() if is_deleted.checked else TodoArchiveIsDeleted.false())
+
+        context = page.get_multi_select("コンテクスト")
+        if context.values:
+            context_names = [v.name for v in context.values]
+            properties.append(TodoArchiveContext.from_name(context_names))
+
+        sort_order = page.get_text("並び順")
+        if sort_order.text:
+            properties.append(TodoArchiveSortOrder.from_plain_text(sort_order.text))
+
+        archive_page = TodoArchivePage.create(properties=properties)
+        self.client.create_page(archive_page)

--- a/src/sandpiper/shared/notion/databases/todo_archive.py
+++ b/src/sandpiper/shared/notion/databases/todo_archive.py
@@ -1,0 +1,74 @@
+from lotion import notion_prop  # type: ignore[import-untyped]
+from lotion.properties import (  # type: ignore[import-untyped]
+    Checkbox,
+    Date,
+    MultiSelect,
+    Number,
+    Relation,
+    Select,
+    Status,
+    Text,
+    Title,
+)
+
+DATABASE_ID = "c776567a3bbf8334b2e3810812854fb3"
+
+
+@notion_prop("名前")
+class TodoArchiveName(Title):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("ステータス")
+class TodoArchiveStatus(Status):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("セクション")
+class TodoArchiveSection(Select):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("今日中にやる")
+class TodoArchiveIsTodayProp(Checkbox):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("実施期間")
+class TodoArchiveLogDate(Date):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("タスク種別")
+class TodoArchiveKindProp(Select):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("プロジェクト")
+class TodoArchiveProjectProp(Relation):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("プロジェクトタスク")
+class TodoArchiveProjectTaskProp(Relation):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("実行時間")
+class TodoArchiveExecutionTime(Number):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("論理削除")
+class TodoArchiveIsDeleted(Checkbox):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("コンテクスト")
+class TodoArchiveContext(MultiSelect):  # type: ignore[misc]
+    ...
+
+
+@notion_prop("並び順")
+class TodoArchiveSortOrder(Text):  # type: ignore[misc]
+    ...

--- a/tests/shared/infrastructure/test_archive_old_todos.py
+++ b/tests/shared/infrastructure/test_archive_old_todos.py
@@ -1,0 +1,204 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sandpiper.shared.infrastructure.archive_old_todos import (
+    DEFAULT_ARCHIVE_DAYS,
+    ArchiveOldTodos,
+    ArchiveOldTodosResult,
+)
+from sandpiper.shared.utils.date_utils import JST
+
+
+class TestArchiveOldTodosResult:
+    def test_archived_count_and_titles(self):
+        result = ArchiveOldTodosResult(
+            archived_count=3,
+            archived_titles=["タスク1", "タスク2", "タスク3"],
+        )
+        assert result.archived_count == 3
+        assert len(result.archived_titles) == 3
+        assert "タスク1" in result.archived_titles
+
+    def test_empty_result(self):
+        result = ArchiveOldTodosResult(
+            archived_count=0,
+            archived_titles=[],
+        )
+        assert result.archived_count == 0
+        assert len(result.archived_titles) == 0
+
+
+class TestArchiveOldTodos:
+    @pytest.fixture
+    def mock_lotion(self):
+        with patch("sandpiper.shared.infrastructure.archive_old_todos.Lotion") as mock:
+            mock_instance = MagicMock()
+            mock.get_instance.return_value = mock_instance
+            yield mock_instance
+
+    @pytest.fixture
+    def mock_jst_now(self):
+        with patch("sandpiper.shared.infrastructure.archive_old_todos.jst_now") as mock:
+            mock.return_value = datetime(2024, 3, 20, 12, 0, 0, tzinfo=JST)
+            yield mock
+
+    def _create_mock_page(
+        self,
+        page_id: str,
+        title: str,
+        status: str,
+        end_datetime: datetime | None,
+    ) -> MagicMock:
+        """テスト用のモックページを作成"""
+        page = MagicMock()
+        page.id = page_id
+        page.get_title_text.return_value = title
+        page.get_status.return_value.status_name = status
+        # start も end と同じ値を設定(Lotion が start なしで end があるとエラーになるため)
+        page.get_date.return_value.start = end_datetime.isoformat() if end_datetime else None
+        page.get_date.return_value.end = end_datetime.isoformat() if end_datetime else None
+        page.get_select.return_value.selected_name = ""
+        page.get_checkbox.return_value.checked = False
+        page.get_relation.return_value.id_list = []
+        page.get_number.return_value.number = None
+        page.get_multi_select.return_value.values = []
+        page.get_text.return_value.text = ""
+        return page
+
+    def test_execute_archives_old_done_todos(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: 10日前に完了したタスク(アーカイブ対象)
+        old_end_date = datetime(2024, 3, 10, 12, 0, 0, tzinfo=JST)
+        page = self._create_mock_page("page-1", "古いタスク", "Done", old_end_date)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 1
+        assert "古いタスク" in result.archived_titles
+        mock_lotion.create_page.assert_called_once()
+        mock_lotion.remove_page.assert_called_once_with("page-1")
+
+    def test_execute_skips_non_done_todos(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: 10日前に完了したが、ステータスがToDo
+        old_end_date = datetime(2024, 3, 10, 12, 0, 0, tzinfo=JST)
+        page = self._create_mock_page("page-1", "未完了タスク", "ToDo", old_end_date)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 0
+        mock_lotion.create_page.assert_not_called()
+        mock_lotion.remove_page.assert_not_called()
+
+    def test_execute_skips_recent_done_todos(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: 3日前に完了(7日未満なのでアーカイブ対象外)
+        recent_end_date = datetime(2024, 3, 17, 12, 0, 0, tzinfo=JST)
+        page = self._create_mock_page("page-1", "最近のタスク", "Done", recent_end_date)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 0
+        mock_lotion.create_page.assert_not_called()
+        mock_lotion.remove_page.assert_not_called()
+
+    def test_execute_skips_done_todos_without_end_date(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: Doneだが終了日時がない
+        page = self._create_mock_page("page-1", "終了日なしタスク", "Done", None)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 0
+        mock_lotion.create_page.assert_not_called()
+        mock_lotion.remove_page.assert_not_called()
+
+    def test_execute_with_dry_run(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: アーカイブ対象のタスク
+        old_end_date = datetime(2024, 3, 10, 12, 0, 0, tzinfo=JST)
+        page = self._create_mock_page("page-1", "古いタスク", "Done", old_end_date)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute(dry_run=True)
+
+        # Assert: 対象として検出されるが、実際のアーカイブは行われない
+        assert result.archived_count == 1
+        assert "古いタスク" in result.archived_titles
+        mock_lotion.create_page.assert_not_called()
+        mock_lotion.remove_page.assert_not_called()
+
+    def test_execute_with_empty_database(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange
+        mock_lotion.retrieve_database.return_value = []
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 0
+        assert len(result.archived_titles) == 0
+
+    def test_execute_with_custom_archive_days(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: 5日前に完了(14日のしきい値未満)
+        end_date = datetime(2024, 3, 15, 12, 0, 0, tzinfo=JST)
+        page = self._create_mock_page("page-1", "5日前タスク", "Done", end_date)
+        mock_lotion.retrieve_database.return_value = [page]
+
+        # Act: 14日のしきい値でテスト
+        usecase = ArchiveOldTodos(archive_days=14)
+        result = usecase.execute()
+
+        # Assert: 5日前なので14日のしきい値を超えていない
+        assert result.archived_count == 0
+
+    def test_execute_archives_multiple_old_todos(self, mock_lotion, mock_jst_now):  # noqa: ARG002
+        # Arrange: 複数のアーカイブ対象タスク
+        old_date1 = datetime(2024, 3, 5, 12, 0, 0, tzinfo=JST)
+        old_date2 = datetime(2024, 3, 8, 12, 0, 0, tzinfo=JST)
+        recent_date = datetime(2024, 3, 18, 12, 0, 0, tzinfo=JST)
+
+        page1 = self._create_mock_page("page-1", "古いタスク1", "Done", old_date1)
+        page2 = self._create_mock_page("page-2", "古いタスク2", "Done", old_date2)
+        page3 = self._create_mock_page("page-3", "最近のタスク", "Done", recent_date)
+        page4 = self._create_mock_page("page-4", "未完了タスク", "ToDo", old_date1)
+
+        mock_lotion.retrieve_database.return_value = [page1, page2, page3, page4]
+
+        # Act
+        usecase = ArchiveOldTodos(archive_days=7)
+        result = usecase.execute()
+
+        # Assert
+        assert result.archived_count == 2
+        assert "古いタスク1" in result.archived_titles
+        assert "古いタスク2" in result.archived_titles
+        assert "最近のタスク" not in result.archived_titles
+        assert "未完了タスク" not in result.archived_titles
+
+    def test_default_archive_days(self):
+        # Assert
+        assert DEFAULT_ARCHIVE_DAYS == 7
+
+    def test_uses_default_archive_days_when_not_provided(self, mock_lotion):  # noqa: ARG002
+        # Act
+        usecase = ArchiveOldTodos()
+
+        # Assert
+        assert usecase.archive_days == DEFAULT_ARCHIVE_DAYS


### PR DESCRIPTION
- Add todo_archive database configuration with same properties as todo db
- Implement ArchiveOldTodos service to move old done todos to archive db
- Add archive-old-todos CLI command with --days and --dry-run options
- Add comprehensive tests for archive functionality