### PR TITLE
chore: Remove unused type ignore comments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ warn_redundant_casts = true
 show_error_codes = true
 show_column_numbers = true
 pretty = true
+disable_error_code = ["import-untyped"]
 
 [[tool.mypy.overrides]]
 module = "tests.*"

--- a/src/sandpiper/calendar/infrastructure/notion_calendar_repository.py
+++ b/src/sandpiper/calendar/infrastructure/notion_calendar_repository.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.calendar.domain.calendar_event import CalendarEvent, EventCategory, InsertedCalendarEvent
 from sandpiper.calendar.domain.calendar_repository import CalendarRepository

--- a/src/sandpiper/clips/infrastructure/notion_clips_repository.py
+++ b/src/sandpiper/clips/infrastructure/notion_clips_repository.py
@@ -1,4 +1,4 @@
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.clips.domain.clip import Clip, InsertedClip
 from sandpiper.clips.domain.clips_repository import ClipsRepository

--- a/src/sandpiper/perform/infrastructure/notion_todo_repository.py
+++ b/src/sandpiper/perform/infrastructure/notion_todo_repository.py
@@ -1,6 +1,6 @@
 import contextlib
 
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.perform.domain.todo import ToDo
 from sandpiper.shared.notion.databases import todo as todo_db

--- a/src/sandpiper/perform/query/incidental_task_query.py
+++ b/src/sandpiper/perform/query/incidental_task_query.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.shared.notion.databases import someday as someday_db
 from sandpiper.shared.valueobject.context import Context

--- a/src/sandpiper/plan/infrastructure/notion_project_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_project_repository.py
@@ -1,5 +1,5 @@
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
-from lotion.filter import Builder, Cond  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
+from lotion.filter import Builder, Cond
 
 from sandpiper.plan.domain.project import InsertedProject, Project
 from sandpiper.shared.notion.databases import project as project_db

--- a/src/sandpiper/plan/infrastructure/notion_project_task_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_project_task_repository.py
@@ -1,4 +1,4 @@
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.plan.domain.project_task import InsertedProjectTask, ProjectTask
 from sandpiper.shared.notion.databases import project_task as project_task_db

--- a/src/sandpiper/plan/infrastructure/notion_routine_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_routine_repository.py
@@ -1,4 +1,4 @@
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.plan.domain.routine import Routine
 from sandpiper.plan.domain.routine_cycle import RoutineCycle

--- a/src/sandpiper/plan/infrastructure/notion_someday_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_someday_repository.py
@@ -1,4 +1,4 @@
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.plan.domain.someday_item import SomedayItem
 from sandpiper.plan.domain.someday_repository import SomedayRepository

--- a/src/sandpiper/plan/infrastructure/notion_todo_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_todo_repository.py
@@ -1,8 +1,8 @@
 from typing import Any
 
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
-from lotion.block import Block  # type: ignore[import-untyped]
-from lotion.block.rich_text.rich_text_builder import RichTextBuilder  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
+from lotion.block import Block
+from lotion.block.rich_text.rich_text_builder import RichTextBuilder
 
 from sandpiper.plan.domain.todo import InsertedToDo, ToDo, ToDoKind, ToDoStatus
 from sandpiper.shared.notion.databases import todo as todo_db

--- a/src/sandpiper/plan/query/project_task_query.py
+++ b/src/sandpiper/plan/query/project_task_query.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.plan.query.project_task_dto import ProjectTaskDto
 from sandpiper.shared.notion.databases import project_task as project_task_db

--- a/src/sandpiper/plan/query/todo_query.py
+++ b/src/sandpiper/plan/query/todo_query.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.plan.domain.todo import ToDo, ToDoKind
 from sandpiper.shared.notion.databases import todo as todo_db

--- a/src/sandpiper/recipe/infrastructure/notion_recipe_repository.py
+++ b/src/sandpiper/recipe/infrastructure/notion_recipe_repository.py
@@ -1,5 +1,5 @@
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
-from lotion.block import BulletedListItem, Heading  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
+from lotion.block import BulletedListItem, Heading
 
 from sandpiper.recipe.domain.recipe import InsertedRecipe, Recipe
 from sandpiper.shared.notion.databases import recipe as recipe_db

--- a/src/sandpiper/recipe/infrastructure/notion_shopping_repository.py
+++ b/src/sandpiper/recipe/infrastructure/notion_shopping_repository.py
@@ -1,4 +1,4 @@
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.shared.notion.databases import shopping as shopping_db
 from sandpiper.shared.notion.databases.shopping import ShoppingName

--- a/src/sandpiper/review/query/calendar_query.py
+++ b/src/sandpiper/review/query/calendar_query.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Protocol
 
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.calendar.infrastructure.notion_calendar_repository import CalendarEventPage
 from sandpiper.review.query.activity_log_item import ActivityLogItem, ActivityType

--- a/src/sandpiper/review/query/todo_query.py
+++ b/src/sandpiper/review/query/todo_query.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Protocol
 
-from lotion import BasePage, Lotion  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion
 
 from sandpiper.plan.domain.todo import ToDoKind
 from sandpiper.review.query.activity_log_item import ActivityLogItem, ActivityType

--- a/src/sandpiper/routers/notion.py
+++ b/src/sandpiper/routers/notion.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from fastapi.responses import JSONResponse
-from lotion import BasePage  # type: ignore[import-untyped]
+from lotion import BasePage
 from pydantic import BaseModel
 
 from sandpiper.app.app import SandPiperApp

--- a/src/sandpiper/shared/infrastructure/archive_deleted_pages.py
+++ b/src/sandpiper/shared/infrastructure/archive_deleted_pages.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 from sandpiper.shared.notion.databases import project_task as project_task_db
 from sandpiper.shared.notion.databases import someday as someday_db

--- a/src/sandpiper/shared/infrastructure/archive_old_todos.py
+++ b/src/sandpiper/shared/infrastructure/archive_old_todos.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from lotion import BasePage, Lotion, notion_database  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database
 
 from sandpiper.shared.notion.databases import todo as todo_db
 from sandpiper.shared.notion.databases import todo_archive as todo_archive_db

--- a/src/sandpiper/shared/infrastructure/notion_commentator.py
+++ b/src/sandpiper/shared/infrastructure/notion_commentator.py
@@ -1,4 +1,4 @@
-from lotion import Lotion  # type: ignore[import-untyped]
+from lotion import Lotion
 
 
 class NotionCommentator:

--- a/src/sandpiper/shared/infrastructure/youtube_client.py
+++ b/src/sandpiper/shared/infrastructure/youtube_client.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from typing import Any
 
 from google.oauth2 import service_account
-from googleapiclient.discovery import build  # type: ignore[import-untyped]
-from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 # サービスアカウントファイルの検索パス(優先順位順)
 SERVICE_ACCOUNT_PATHS = [

--- a/src/sandpiper/shared/notion/databases/calendar.py
+++ b/src/sandpiper/shared/notion/databases/calendar.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Date, Select, Title  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Date, Select, Title
 
 DATABASE_ID = "2dd6567a3bbf80219a93f941334bd556"
 

--- a/src/sandpiper/shared/notion/databases/clips.py
+++ b/src/sandpiper/shared/notion/databases/clips.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Checkbox, Select, Title, Url  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Checkbox, Select, Title, Url
 
 DATABASE_ID = "2e66567a3bbf80aa8c83f113aa101d44"  # TODO: 実際のNotion Clips Database IDに置き換えてください
 

--- a/src/sandpiper/shared/notion/databases/inbox.py
+++ b/src/sandpiper/shared/notion/databases/inbox.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Select, Title, Url  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Select, Title, Url
 
 
 class InboxType(Enum):

--- a/src/sandpiper/shared/notion/databases/project.py
+++ b/src/sandpiper/shared/notion/databases/project.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Date, Status, Title, Url  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Date, Status, Title, Url
 
 DATABASE_ID = "458c69ce4e1c49fe810cf26c2291e294"
 

--- a/src/sandpiper/shared/notion/databases/project_task.py
+++ b/src/sandpiper/shared/notion/databases/project_task.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Checkbox, MultiSelect, Relation, Status, Text, Title  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Checkbox, MultiSelect, Relation, Status, Text, Title
 
 DATABASE_ID = "2db6567a3bbf80078961d42908b5dd49"
 

--- a/src/sandpiper/shared/notion/databases/recipe.py
+++ b/src/sandpiper/shared/notion/databases/recipe.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Relation, Title, Url  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Relation, Title, Url
 
 DATABASE_ID = "64b6d5f1254741a2a74d25f0c4df041e"
 

--- a/src/sandpiper/shared/notion/databases/routine.py
+++ b/src/sandpiper/shared/notion/databases/routine.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Date, MultiSelect, Number, Text  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Date, MultiSelect, Number, Text
 
 DATABASE_ID = "d21db86c92034ff498999d62354e8fe1"
 

--- a/src/sandpiper/shared/notion/databases/shopping.py
+++ b/src/sandpiper/shared/notion/databases/shopping.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Title  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import Title
 
 DATABASE_ID = "b917fd7e2fe54030879f9eea5e8827bb"
 

--- a/src/sandpiper/shared/notion/databases/someday.py
+++ b/src/sandpiper/shared/notion/databases/someday.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from lotion import BasePage, Lotion, notion_database, notion_prop  # type: ignore[import-untyped]
-from lotion.properties import Checkbox, MultiSelect, Select, Title  # type: ignore[import-untyped]
+from lotion import BasePage, Lotion, notion_database, notion_prop
+from lotion.properties import Checkbox, MultiSelect, Select, Title
 
 if TYPE_CHECKING:
     from sandpiper.plan.domain.someday_item import SomedayItem

--- a/src/sandpiper/shared/notion/databases/todo.py
+++ b/src/sandpiper/shared/notion/databases/todo.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import (  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import (
     Checkbox,
     Date,
     MultiSelect,

--- a/src/sandpiper/shared/notion/databases/todo_archive.py
+++ b/src/sandpiper/shared/notion/databases/todo_archive.py
@@ -1,5 +1,5 @@
-from lotion import notion_prop  # type: ignore[import-untyped]
-from lotion.properties import (  # type: ignore[import-untyped]
+from lotion import notion_prop
+from lotion.properties import (
     Checkbox,
     Date,
     MultiSelect,

--- a/src/sandpiper/shared/utils/date_utils.py
+++ b/src/sandpiper/shared/utils/date_utils.py
@@ -102,7 +102,9 @@ def jst_tomorrow() -> datetime:
 jst_tommorow = jst_tomorrow
 
 
-def convert_to_date_or_datetime[D: date](value: str | None, cls: type[D] | None = None) -> D | None:
+def convert_to_date_or_datetime(
+    value: str | None, cls: type[date] | type[datetime] | None = None
+) -> date | datetime | None:
     """ISO形式の文字列をdateまたはdatetimeに変換する.
 
     Args:
@@ -124,13 +126,13 @@ def convert_to_date_or_datetime[D: date](value: str | None, cls: type[D] | None 
         return None
     date_type = DateType.get_datetype(value)
     if date_type == DateType.DATE:
-        return _convert_date(value, cls)  # type: ignore[return-value]
+        return _convert_date(value, cls)
     if date_type == DateType.DATETIME:
-        return _convert_datetime(value, cls)  # type: ignore[return-value]
+        return _convert_datetime(value, cls)
     return None
 
 
-def _convert_date[D: date](value: str, cls: type[D] | None) -> date | datetime:
+def _convert_date(value: str, cls: type[date] | type[datetime] | None) -> date | datetime:
     """日付文字列をdate/datetimeに変換する(内部関数).
 
     Args:
@@ -147,7 +149,7 @@ def _convert_date[D: date](value: str, cls: type[D] | None) -> date | datetime:
     return datetime(parsed_date.year, parsed_date.month, parsed_date.day, tzinfo=JST)
 
 
-def _convert_datetime[D: date](value: str, cls: type[D] | None) -> date | datetime:
+def _convert_datetime(value: str, cls: type[date] | type[datetime] | None) -> date | datetime:
     """日時文字列をdate/datetimeに変換する(内部関数).
 
     Args:


### PR DESCRIPTION
- Remove unused `# type: ignore[import-untyped]` comments from lotion and googleapiclient imports across all files
- Fix PEP 695 generics issue in date_utils.py by using simple type annotations
- Add `disable_error_code = ["import-untyped"]` to mypy config to globally suppress import-untyped errors for third-party libraries without type stubs

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
