### PR TITLE
chore: Ignore CVE-2026-0994 protobuf vulnerability in security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run security audit
-        run: uv run pip-audit
+        # CVE-2026-0994: protobuf vulnerability - no fix version available yet
+        # protobuf is a transitive dependency from google-api-python-client
+        # Remove --ignore-vuln once a fix is released
+        run: uv run pip-audit --ignore-vuln CVE-2026-0994


### PR DESCRIPTION
# Pull Request

## 概要
セキュリティ監査時にCVE-2026-0994（protobufの脆弱性）を無視するように設定しました。この脆弱性は`google-api-python-client`の推移的依存関係から発生しており、現在修正版がリリースされていません。

## 変更の種類
- [x] 🔧 Configuration (設定変更)

## Conventional Commits
`chore: セキュリティ監査でCVE-2026-0994を無視`

## 詳細
- **変更内容**: CI/CDパイプラインの`pip-audit`コマンドに`--ignore-vuln CVE-2026-0994`フラグを追加
- **理由**: protobufの脆弱性（CVE-2026-0994）は`google-api-python-client`の推移的依存関係から発生しており、現在修正版がリリースされていないため
- **対応**: 修正版がリリースされたら、このフラグを削除する予定

## チェックリスト
- [x] コードが正しくフォーマットされている
- [x] リンティングエラーがない
- [x] 型チェックが通る
- [x] テストが通る
- [x] 新機能にテストを追加した(該当なし)
- [x] ドキュメントを更新した(該当なし)