### PR TITLE
feat: Notion側にのみ存在するプロジェクトの検出機能を追加

### DIFF
--- a/src/sandpiper/main.py
+++ b/src/sandpiper/main.py
@@ -701,9 +701,20 @@ def sync_jira_to_project(
             for ticket in result.skipped_tickets:
                 console.print(f"  - {ticket.issue_key}: {ticket.summary}")
 
+        # Notionにのみ存在するプロジェクト (JIRA側で完了済み等)
+        if result.notion_only_projects:
+            console.print(f"\n[magenta][bold]Notionのみに存在 ({len(result.notion_only_projects)}件):[/bold][/magenta]")
+            console.print("[dim]※JIRA側で完了済みまたはステータス変更の可能性があります[/dim]")
+            for project in result.notion_only_projects:
+                console.print(f"  - {project.name}")
+                if project.jira_url:
+                    console.print(f"    [blue]{project.jira_url}[/blue]")
+
         # サマリー
         console.print(
-            f"\n[bold]同期完了: {len(result.created_projects)}件作成, {len(result.skipped_tickets)}件スキップ[/bold]"
+            f"\n[bold]同期完了: {len(result.created_projects)}件作成, "
+            f"{len(result.skipped_tickets)}件スキップ, "
+            f"{len(result.notion_only_projects)}件Notionのみ[/bold]"
         )
 
     except ValueError as e:

--- a/src/sandpiper/plan/domain/project_repository.py
+++ b/src/sandpiper/plan/domain/project_repository.py
@@ -21,3 +21,7 @@ class ProjectRepository(Protocol):
     def fetch_all_jira_urls(self) -> set[str]:
         """すべてのプロジェクトからJira URLの一覧を取得する"""
         ...
+
+    def fetch_projects_with_jira_url(self) -> list[InsertedProject]:
+        """Jira URLを持つすべてのプロジェクトを取得する"""
+        ...

--- a/src/sandpiper/plan/infrastructure/notion_project_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_project_repository.py
@@ -131,3 +131,11 @@ class NotionProjectRepository:
             if jira_url_prop and jira_url_prop.url:
                 jira_urls.add(jira_url_prop.url)
         return jira_urls
+
+    def fetch_projects_with_jira_url(self) -> list[InsertedProject]:
+        """Jira URLを持つすべてのプロジェクトを取得する"""
+        filter_param = Builder.create().add(ProjectJiraUrl, Cond.IS_NOT_EMPTY).build()
+        pages: list[ProjectPage] = self.client.retrieve_database(
+            database_id=project_db.DATABASE_ID, filter_param=filter_param, cls=ProjectPage
+        )
+        return [page.to_inserted() for page in pages]


### PR DESCRIPTION
## 概要
JIRA側で完了済みまたは削除されたが、Notion側に残っているプロジェクトを検出・表示する機能を追加しました。同期結果に「Notionのみに存在するプロジェクト」として表示され、ユーザーが手動で対応できるようになります。

## 変更の種類
- [x] ✨ New feature (新機能)

## 詳細な変更内容

### 1. データモデルの拡張
- `SyncJiraToProjectResult`に`notion_only_projects`フィールドを追加
- Notion側にのみ存在するプロジェクトを結果に含めるようにしました

### 2. リポジトリインターフェースの拡張
- `ProjectRepository`に`fetch_projects_with_jira_url()`メソッドを追加
- Jira URLを持つすべてのプロジェクトを効率的に取得できるようにしました

### 3. Notion実装の追加
- `NotionProjectRepository`に`fetch_projects_with_jira_url()`を実装
- Jira URLが空でないプロジェクトをフィルタリングして取得します

### 4. 同期ロジックの改善
- JIRAから取得したチケットのURLセットを作成
- Notion側のプロジェクトと比較して、以下の条件で「Notionのみ」を判定:
  - Jira URLを持つ
  - 対象JIRAプロジェクト(例: SU)のURLパターンに一致
  - JIRAの現在のチケットに存在しない

### 5. UI/UXの改善
- 同期結果に「Notionのみに存在」セクションを追加
- プロジェクト名とJira URLを表示
- 注釈「※JIRA側で完了済みまたはステータス変更の可能性があります」を表示
- サマリーに件数を追加

### 6. テストの充実
- 既存テストを新しいメソッドに対応させました
- 3つの新しいテストケースを追加:
  - `test_execute_detects_notion_only_projects`: 基本的な検出機能
  - `test_execute_notion_only_filters_by_jira_project`: プロジェクトキーでのフィルタリング
  - `test_execute_no_notion_only_when_all_match`: 一致時は空になることの確認

## Conventional Commits
`feat: Notion側にのみ存在するプロジェクトの検出機能を追加`

## チェックリスト
- [x] コードが正しくフォーマットされている
- [x] リンティングエラーがない
- [x] 型チェックが通る
- [x] テストが通る
- [x] 新機能にテストを追加した
- [ ] ドキュメントを更新した(該当なし)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->

https://claude.ai/code/session_01FjBwrpN7yQ78XNkpaKn6JV