### PR TITLE
fix: Add JST timezone to scheduled datetime creation

### DIFF
--- a/src/sandpiper/plan/application/create_repeat_task.py
+++ b/src/sandpiper/plan/application/create_repeat_task.py
@@ -5,6 +5,7 @@ from sandpiper.plan.domain.routine_repository import RoutineRepository
 from sandpiper.plan.domain.todo import ToDo, ToDoKind
 from sandpiper.plan.domain.todo_repository import TodoRepository
 from sandpiper.plan.query.todo_query import TodoQuery
+from sandpiper.shared.utils.date_utils import JST
 
 
 @dataclass
@@ -48,9 +49,9 @@ class CreateRepeatTask:
             scheduled_start_datetime = None
             scheduled_end_datetime = None
             if routine.scheduled_start_time:
-                scheduled_start_datetime = datetime.combine(basis_date, routine.scheduled_start_time)
+                scheduled_start_datetime = datetime.combine(basis_date, routine.scheduled_start_time, tzinfo=JST)
             if routine.scheduled_end_time:
-                scheduled_end_datetime = datetime.combine(basis_date, routine.scheduled_end_time)
+                scheduled_end_datetime = datetime.combine(basis_date, routine.scheduled_end_time, tzinfo=JST)
             todo = ToDo(
                 title=routine.title,
                 section=routine.section,

--- a/src/sandpiper/plan/query/project_task_dto.py
+++ b/src/sandpiper/plan/query/project_task_dto.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, time
 from typing import Any
 
 from sandpiper.plan.domain.todo import ToDo, ToDoKind
+from sandpiper.shared.utils.date_utils import JST
 from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
 
 
@@ -24,9 +25,9 @@ class ProjectTaskDto:
         scheduled_start_datetime = None
         scheduled_end_datetime = None
         if self.scheduled_start_time:
-            scheduled_start_datetime = datetime.combine(basis_date, self.scheduled_start_time)
+            scheduled_start_datetime = datetime.combine(basis_date, self.scheduled_start_time, tzinfo=JST)
         if self.scheduled_end_time:
-            scheduled_end_datetime = datetime.combine(basis_date, self.scheduled_end_time)
+            scheduled_end_datetime = datetime.combine(basis_date, self.scheduled_end_time, tzinfo=JST)
 
         return ToDo(
             title=self.title,


### PR DESCRIPTION
# Pull Request

## 概要
スケジュール済みタスクの開始時刻と終了時刻を作成する際に、JST（日本標準時）タイムゾーン情報を追加しました。これにより、タイムゾーン非対応のnaive datetimeオブジェクトではなく、タイムゾーン対応のaware datetimeオブジェクトが生成されるようになります。

## 変更の種類
- [x] 🐛 Bug fix (バグ修正)

## 変更内容
- `create_repeat_task.py`: `datetime.combine()`呼び出しに`tzinfo=JST`パラメータを追加
- `project_task_dto.py`: `datetime.combine()`呼び出しに`tzinfo=JST`パラメータを追加
- 両ファイルで`JST`をインポート

## Conventional Commits
```
fix: Add JST timezone to scheduled datetime creation
```

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

https://claude.ai/code/session_01D1kwNgEhwDpBqjg1NQyVgW