### PR TITLE
chore: code formatting and cleanup

### DIFF
--- a/src/sandpiper/plan/application/create_schedule_tasks.py
+++ b/src/sandpiper/plan/application/create_schedule_tasks.py
@@ -94,7 +94,9 @@ class CreateScheduleTasks:
                 sort_order=sort_order,
             )
 
-            print(f"Create schedule task: {event.name} (section: {section.value}, duration: {execution_time}min, sort: {sort_order})")
+            print(
+                f"Create schedule task: {event.name} (section: {section.value}, duration: {execution_time}min, sort: {sort_order})"
+            )
 
             if not self.is_debug:
                 self.todo_repository.save(todo)

--- a/src/sandpiper/plan/domain/routine.py
+++ b/src/sandpiper/plan/domain/routine.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
-from datetime import date as Date, time
+from datetime import date as Date
+from datetime import time
 from typing import Any
 
 from sandpiper.plan.domain.routine_cycle import RoutineCycle

--- a/tests/plan/application/test_create_schedule_tasks.py
+++ b/tests/plan/application/test_create_schedule_tasks.py
@@ -12,7 +12,6 @@ from sandpiper.plan.query.todo_query import TodoQuery
 from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
 
 # テスト用タイムゾーン
-UTC = timezone.utc
 JST = timezone(timedelta(hours=9))
 
 
@@ -45,7 +44,7 @@ class TestCalendarEventDto:
         assert event.calculate_duration_minutes() == 120
 
     def test_get_sort_order_morning_utc(self):
-        """UTC午前のイベントの並び順取得（JST変換後）"""
+        """UTC午前のイベントの並び順取得(JST変換後)"""
         # UTC 00:30 → JST 09:30
         event = CalendarEventDto(
             name="朝会",
@@ -55,7 +54,7 @@ class TestCalendarEventDto:
         assert event.get_sort_order() == "09:30"
 
     def test_get_sort_order_afternoon_utc(self):
-        """UTC午後のイベントの並び順取得（JST変換後）"""
+        """UTC午後のイベントの並び順取得(JST変換後)"""
         # UTC 05:15 → JST 14:15
         event = CalendarEventDto(
             name="午後の会議",
@@ -65,7 +64,7 @@ class TestCalendarEventDto:
         assert event.get_sort_order() == "14:15"
 
     def test_get_sort_order_midnight_utc(self):
-        """UTC深夜のイベントの並び順取得（JST変換後）"""
+        """UTC深夜のイベントの並び順取得(JST変換後)"""
         # UTC 15:05 → JST 翌日00:05
         event = CalendarEventDto(
             name="深夜作業",

--- a/tests/plan/application/test_sync_jira_to_project.py
+++ b/tests/plan/application/test_sync_jira_to_project.py
@@ -285,7 +285,11 @@ class TestSyncJiraToProject:
         assert mock_project_task_repository.save.call_count == 1
 
     def test_execute_detects_notion_only_projects(
-        self, sync_jira_to_project, mock_jira_ticket_query, mock_project_repository, mock_project_task_repository
+        self,
+        sync_jira_to_project,
+        mock_jira_ticket_query,
+        mock_project_repository,
+        mock_project_task_repository,  # noqa: ARG002
     ):
         """JIRA側に存在しないNotionプロジェクトをnotion_only_projectsとして検出する"""
         # Arrange
@@ -299,7 +303,7 @@ class TestSyncJiraToProject:
         )
         mock_jira_ticket_query.search_tickets.return_value = [ticket]
 
-        # NotionにはSU-500とSU-999の両方が存在（SU-999はJIRA側で完了済み）
+        # NotionにはSU-500とSU-999の両方が存在(SU-999はJIRA側で完了済み)
         active_project = InsertedProject(
             id="active-project-id",
             name="Active feature",
@@ -326,7 +330,11 @@ class TestSyncJiraToProject:
         assert result.notion_only_projects[0].jira_url == "https://jira.example.com/browse/SU-999"
 
     def test_execute_notion_only_filters_by_jira_project(
-        self, sync_jira_to_project, mock_jira_ticket_query, mock_project_repository, mock_project_task_repository
+        self,
+        sync_jira_to_project,
+        mock_jira_ticket_query,
+        mock_project_repository,
+        mock_project_task_repository,  # noqa: ARG002
     ):
         """notion_only_projectsは対象JIRAプロジェクトのものだけをフィルタリングする"""
         # Arrange
@@ -357,7 +365,11 @@ class TestSyncJiraToProject:
         assert result.notion_only_projects[0].jira_url == "https://jira.example.com/browse/SU-888"
 
     def test_execute_no_notion_only_when_all_match(
-        self, sync_jira_to_project, mock_jira_ticket_query, mock_project_repository, mock_project_task_repository
+        self,
+        sync_jira_to_project,
+        mock_jira_ticket_query,
+        mock_project_repository,
+        mock_project_task_repository,  # noqa: ARG002
     ):
         """JIRAとNotionのプロジェクトがすべて一致する場合はnotion_only_projectsは空"""
         # Arrange


### PR DESCRIPTION
## 概要
コードフォーマットとクリーンアップを実施しました。Ruffのフォーマッタとリンターの指摘に対応し、コード品質を向上させています。

## 変更の種類
- [x] 🧹 Code cleanup (コード整理)

## 詳細な変更内容

### src/sandpiper/plan/application/create_schedule_tasks.py
- 長い行を複数行に分割してフォーマット（94-99行目）

### src/sandpiper/plan/domain/routine.py
- インポート文を整理：`from datetime import date as Date, time` を2行に分割
  - `from datetime import date as Date`
  - `from datetime import time`

### tests/plan/application/test_create_schedule_tasks.py
- 未使用の `UTC` 変数を削除（15行目）
- 日本語コメント内の全角括弧を半角括弧に統一（3箇所）
  - `（JST変換後）` → `(JST変換後)`

### tests/plan/application/test_sync_jira_to_project.py
- メソッドシグネチャの長い行を複数行に分割（3箇所）
  - `test_execute_detects_notion_only_projects`
  - `test_execute_notion_only_filters_by_jira_project`
  - `test_execute_no_notion_only_when_all_match`
- 未使用パラメータに `# noqa: ARG002` コメントを追加
- 日本語コメント内の全角括弧を半角括弧に統一（1箇所）

## Conventional Commits
`chore: code formatting and cleanup`

## チェックリスト
- [x] コードが正しくフォーマットされている (`uv run ruff format .`)
- [x] リンティングエラーがない (`uv run ruff check .`)
- [x] 型チェックが通る (`uv run mypy`)
- [x] テストが通る (`uv run pytest`)

https://claude.ai/code/session_015fkRRpEe53w7Z3u5VpmczH