### PR TITLE
feat: Support date-only scheduling for tasks without specific times

### DIFF
--- a/src/sandpiper/plan/domain/todo.py
+++ b/src/sandpiper/plan/domain/todo.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 
 from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
@@ -25,8 +25,8 @@ class ToDo:
     execution_time: int | None = None
     context: list[str] | None = None
     sort_order: str | None = None
-    scheduled_start_datetime: datetime | None = None
-    scheduled_end_datetime: datetime | None = None
+    scheduled_start_datetime: datetime | date | None = None
+    scheduled_end_datetime: datetime | date | None = None
 
 
 @dataclass
@@ -38,5 +38,5 @@ class InsertedToDo:
     execution_time: int | None = None
     context: list[str] | None = None
     sort_order: str | None = None
-    scheduled_start_datetime: datetime | None = None
-    scheduled_end_datetime: datetime | None = None
+    scheduled_start_datetime: datetime | date | None = None
+    scheduled_end_datetime: datetime | date | None = None

--- a/src/sandpiper/plan/query/project_task_dto.py
+++ b/src/sandpiper/plan/query/project_task_dto.py
@@ -22,12 +22,15 @@ class ProjectTaskDto:
     is_work_project: bool = False
 
     def to_todo_model(self, basis_date: date) -> ToDo:
-        scheduled_start_datetime = None
-        scheduled_end_datetime = None
+        scheduled_start_datetime: datetime | date | None = None
+        scheduled_end_datetime: datetime | None = None
         if self.scheduled_start_time:
             scheduled_start_datetime = datetime.combine(basis_date, self.scheduled_start_time, tzinfo=JST)
         if self.scheduled_end_time:
             scheduled_end_datetime = datetime.combine(basis_date, self.scheduled_end_time, tzinfo=JST)
+        # 予定時刻が未定の場合は、日付のみを設定
+        if scheduled_start_datetime is None and scheduled_end_datetime is None:
+            scheduled_start_datetime = basis_date
 
         return ToDo(
             title=self.title,

--- a/tests/plan/query/test_project_task_dto.py
+++ b/tests/plan/query/test_project_task_dto.py
@@ -128,7 +128,7 @@ class TestProjectTaskDto:
         assert todo.scheduled_end_datetime == datetime(2024, 3, 20, 10, 30, tzinfo=JST)
 
     def test_to_todo_model_without_scheduled_time(self):
-        """to_todo_model()が時刻なしの場合はNoneを返すことをテスト"""
+        """to_todo_model()が時刻なしの場合は日付のみを設定することをテスト"""
         # Arrange
         dto = ProjectTaskDto(
             page_id="task-123",
@@ -142,8 +142,8 @@ class TestProjectTaskDto:
         # Act
         todo = dto.to_todo_model(basis_date)
 
-        # Assert
-        assert todo.scheduled_start_datetime is None
+        # Assert - 予定時刻が未定の場合は、日付のみが設定される
+        assert todo.scheduled_start_datetime == basis_date
         assert todo.scheduled_end_datetime is None
 
     def test_to_todo_model_different_statuses(self):


### PR DESCRIPTION
# Pull Request

## 概要
タスクの予定時刻が未定の場合に、日付のみを `scheduled_start_datetime` に設定するように変更しました。これにより、時刻が指定されていないタスクでも日付情報を保持できるようになります。

## 変更の種類
- [x] ✨ New feature (新機能)

## 詳細な変更内容

### 1. ToDo モデルの型定義更新
- `scheduled_start_datetime` と `scheduled_end_datetime` の型を `datetime | date | None` に拡張
- `InsertedToDo` クラスも同様に更新

### 2. ProjectTaskDto の変換ロジック改善
- `to_todo_model()` メソッドで、予定時刻が両方とも未定の場合に `basis_date` を `scheduled_start_datetime` に設定
- 型アノテーションを明示的に追加

### 3. テストの更新
- `test_to_todo_model_without_scheduled_time()` のテストケースを更新
- 予定時刻なしの場合、`scheduled_start_datetime` が `basis_date` に設定されることを確認

## Conventional Commits
`feat: Support date-only scheduling for tasks without specific times`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [x] 新機能にテストを追加した
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->

https://claude.ai/code/session_0168Y5x7G6jK5tE9BUr7zCJa