### PR TITLE
feat: override_section_by_schedule に一括実行機能を追加

### DIFF
--- a/src/sandpiper/perform/application/override_section_by_schedule.py
+++ b/src/sandpiper/perform/application/override_section_by_schedule.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 from sandpiper.perform.domain.todo_repository import TodoRepository
 from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
+from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
 
 # JSTオフセット
 JST_OFFSET = timedelta(hours=9)
@@ -19,6 +20,18 @@ class OverrideSectionResult:
     old_section: TaskChuteSection | None
     new_section: TaskChuteSection
     scheduled_start_datetime_str: str
+
+
+@dataclass
+class OverrideSectionBulkResult:
+    """一括セクション上書き結果"""
+
+    results: list[OverrideSectionResult]
+    skipped_count: int  # 予定開始時刻がないためスキップした件数
+
+    @property
+    def success_count(self) -> int:
+        return len(self.results)
 
 
 class OverrideSectionBySchedule:
@@ -64,4 +77,28 @@ class OverrideSectionBySchedule:
             old_section=todo.section,
             new_section=new_section,
             scheduled_start_datetime_str=scheduled_jst.strftime("%Y-%m-%d %H:%M"),
+        )
+
+    def execute_all(self) -> OverrideSectionBulkResult:
+        """
+        ステータスがTODOのすべてのタスクに対して、予定開始時刻からセクションを上書きする
+
+        Returns:
+            OverrideSectionBulkResult: 一括上書き結果
+        """
+        todos = self._todo_repository.find_by_status(ToDoStatusEnum.TODO)
+        results: list[OverrideSectionResult] = []
+        skipped_count = 0
+
+        for todo in todos:
+            if todo.scheduled_start_datetime is None:
+                skipped_count += 1
+                continue
+
+            result = self.execute(todo.id)
+            results.append(result)
+
+        return OverrideSectionBulkResult(
+            results=results,
+            skipped_count=skipped_count,
         )

--- a/src/sandpiper/perform/domain/todo_repository.py
+++ b/src/sandpiper/perform/domain/todo_repository.py
@@ -2,10 +2,13 @@ from typing import Protocol
 
 from sandpiper.perform.domain.todo import ToDo
 from sandpiper.shared.valueobject.task_chute_section import TaskChuteSection
+from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
 
 
 class TodoRepository(Protocol):
     def find(self, page_id: str) -> ToDo: ...
+
+    def find_by_status(self, status: ToDoStatusEnum) -> list[ToDo]: ...
 
     def save(self, todo: ToDo) -> None: ...
 

--- a/src/sandpiper/perform/infrastructure/notion_todo_repository.py
+++ b/src/sandpiper/perform/infrastructure/notion_todo_repository.py
@@ -85,3 +85,14 @@ class NotionTodoRepository:
         page = self.client.retrieve_page(page_id, TodoPage)
         page.set_prop(TodoSection.from_name(section.value))
         self.client.update(page)
+
+    def find_by_status(self, status: ToDoStatusEnum) -> list[ToDo]:
+        """指定されたステータスのTODOリストを取得する"""
+        pages = self.client.retrieve_database(todo_db.DATABASE_ID)
+        result: list[ToDo] = []
+        for page in pages:
+            page_status = ToDoStatusEnum(page.get_status("ステータス").status_name)
+            if page_status == status:
+                todo_page = self.client.retrieve_page(page.id, TodoPage)
+                result.append(todo_page.to_domain())
+        return result


### PR DESCRIPTION
## 概要
`override_section_by_schedule` コマンドに一括実行機能を追加しました。page_id を省略した場合、ステータスが TODO のすべてのタスクを対象に予定開始時刻からセクションを自動上書きできるようになります。

## 変更の種類
- [x] ✨ New feature (新機能)

## 詳細な変更内容

### 1. CLI コマンド (`main.py`)
- `page_id` 引数を必須から省略可能に変更
- page_id が指定された場合：単体実行（既存動作）
- page_id が省略された場合：一括実行（新機能）
- 一括実行時は成功件数とスキップ件数を表示

### 2. ユースケース層 (`override_section_by_schedule.py`)
- `OverrideSectionBulkResult` クラスを新規追加
  - 複数タスクの処理結果を管理
  - `success_count` プロパティで成功件数を計算
  - `skipped_count` でスキップ件数を記録
- `execute_all()` メソッドを新規追加
  - TODO ステータスのすべてのタスクを取得
  - 予定開始時刻がないタスクはスキップ
  - 各タスクに対して `execute()` を実行

### 3. リポジトリ層
- `TodoRepository` に `find_by_status()` メソッドを追加（Protocol）
- `NotionTodoRepository` に `find_by_status()` の実装を追加
  - Notion データベースからステータスで検索

### 4. テスト (`test_override_section_by_schedule.py`)
- `execute_all()` メソッドの包括的なテストを追加
  - 予定開始日時ありのタスク処理
  - 予定開始日時なしのタスクスキップ
  - 混在パターン
  - 空リストパターン

## 動作例

```bash
# 単体実行（既存）
$ sandpiper override-section-by-schedule page-id-123

# 一括実行（新機能）
$ sandpiper override-section-by-schedule
ステータスがTODOのすべてのタスクを処理中...
セクション上書き完了: 5件
スキップ: 2件 (予定開始時刻なし)
  - タスク1: なし → A_07_10
  - タスク2: B_10_13 → C_13_16
  ...
```

## Conventional Commits
`feat: override_section_by_schedule に一括実行機能を追加`

## チェックリスト
- [x] コードが正しくフォーマットされている
- [x] リンティングエラーがない
- [x] 型チェックが通る
- [x] テストが通る
- [x] 新機能にテストを追加した
- [x] ドキュメント（docstring）を更新した

https://claude.ai/code/session_01T4CQZs8wJYjjNVUEfvVj3k