### PR TITLE
feat: Add individual weekly and monthly routine cycles

### DIFF
--- a/src/sandpiper/plan/domain/routine_cycle.py
+++ b/src/sandpiper/plan/domain/routine_cycle.py
@@ -2,8 +2,11 @@ from datetime import date, timedelta
 from enum import Enum
 
 MONTHLY_OVERFLOW = 13
-FRIDAY = 4
+SUNDAY = 6
+MONDAY = 0
+TUESDAY = 1
 THURSDAY = 3
+FRIDAY = 4
 
 
 def add_a_month(date: date) -> tuple[int, int]:
@@ -124,13 +127,19 @@ class RoutineCycle(Enum):
     """
 
     DAILY = "毎日"
+    WEEKLY_SUN = "毎週日"
+    WEEKLY_MON = "毎週月"
+    WEEKLY_TUE = "毎週火"
     WEEKLY_TUE_FRI = "毎週火・金"
     WEEKLY_WED = "毎週水"
+    WEEKLY_THU = "毎週木"
+    WEEKLY_FRI = "毎週金"
     WEEKLY_SAT = "毎週土"
     AFTER_3_DAYS = "3日後"
     AFTER_7_DAYS = "7日後"
     NEXT_WEEK = "翌週"
     MONTHLY_1ST = "毎月1日"
+    MONTHLY_2ND = "毎月2日"
     MONTH_END = "月末"
     AFTER_20_DAYS = "20日後"
     MONTHLY_25TH = "毎月25日"
@@ -159,6 +168,21 @@ class RoutineCycle(Enum):
         match self:
             case RoutineCycle.DAILY:
                 return basis_date + timedelta(days=1)
+            case RoutineCycle.WEEKLY_SUN:
+                days_until_sun = (SUNDAY - weekday) % 7
+                if days_until_sun == 0:  # 日曜日の場合は次の日曜日へ
+                    return basis_date + timedelta(days=7)
+                return basis_date + timedelta(days=days_until_sun)
+            case RoutineCycle.WEEKLY_MON:
+                days_until_mon = (MONDAY - weekday) % 7
+                if days_until_mon == 0:  # 月曜日の場合は次の月曜日へ
+                    return basis_date + timedelta(days=7)
+                return basis_date + timedelta(days=days_until_mon)
+            case RoutineCycle.WEEKLY_TUE:
+                days_until_tue = (TUESDAY - weekday) % 7
+                if days_until_tue == 0:  # 火曜日の場合は次の火曜日へ
+                    return basis_date + timedelta(days=7)
+                return basis_date + timedelta(days=days_until_tue)
             case RoutineCycle.WEEKLY_TUE_FRI:
                 if weekday == 1:  # 火曜日の場合は金曜日へ
                     return basis_date + timedelta(days=3)
@@ -173,6 +197,16 @@ class RoutineCycle(Enum):
                 if days_until_wed == 0:  # 水曜日の場合は次の水曜日へ
                     return basis_date + timedelta(days=7)
                 return basis_date + timedelta(days=days_until_wed)
+            case RoutineCycle.WEEKLY_THU:
+                days_until_thu = (THURSDAY - weekday) % 7
+                if days_until_thu == 0:  # 木曜日の場合は次の木曜日へ
+                    return basis_date + timedelta(days=7)
+                return basis_date + timedelta(days=days_until_thu)
+            case RoutineCycle.WEEKLY_FRI:
+                days_until_fri = (FRIDAY - weekday) % 7
+                if days_until_fri == 0:  # 金曜日の場合は次の金曜日へ
+                    return basis_date + timedelta(days=7)
+                return basis_date + timedelta(days=days_until_fri)
             case RoutineCycle.WEEKLY_SAT:
                 days_until_sat = (5 - weekday) % 7
                 if days_until_sat == 0:  # 土曜日の場合は次の土曜日へ
@@ -187,6 +221,12 @@ class RoutineCycle(Enum):
             case RoutineCycle.MONTHLY_1ST:
                 year, month = add_a_month(basis_date)
                 return date(year=year, month=month, day=1)
+            case RoutineCycle.MONTHLY_2ND:
+                date_ = basis_date.replace(day=2)
+                if basis_date < date_:
+                    return date_
+                year, month = add_a_month(basis_date)
+                return date(year=year, month=month, day=2)
             case RoutineCycle.MONTH_END:
                 month = basis_date.month + 1
                 if month == MONTHLY_OVERFLOW:

--- a/tests/plan/domain/test_routine_cycle.py
+++ b/tests/plan/domain/test_routine_cycle.py
@@ -74,6 +74,66 @@ class TestRoutineCycleNextDate:
         result = RoutineCycle.WEEKLY_SAT.next_date(basis_date)
         assert result == date(2026, 1, 17)  # 土曜日
 
+    def test_weekly_sun_on_monday(self):
+        """WEEKLY_SUNの月曜日の場合、次の日曜日が返される."""
+        basis_date = date(2026, 1, 5)  # 月曜日
+        result = RoutineCycle.WEEKLY_SUN.next_date(basis_date)
+        assert result == date(2026, 1, 11)  # 日曜日
+
+    def test_weekly_sun_on_sunday(self):
+        """WEEKLY_SUNの日曜日の場合、次の日曜日が返される."""
+        basis_date = date(2026, 1, 11)  # 日曜日
+        result = RoutineCycle.WEEKLY_SUN.next_date(basis_date)
+        assert result == date(2026, 1, 18)  # 日曜日
+
+    def test_weekly_mon_on_tuesday(self):
+        """WEEKLY_MONの火曜日の場合、次の月曜日が返される."""
+        basis_date = date(2026, 1, 6)  # 火曜日
+        result = RoutineCycle.WEEKLY_MON.next_date(basis_date)
+        assert result == date(2026, 1, 12)  # 月曜日
+
+    def test_weekly_mon_on_monday(self):
+        """WEEKLY_MONの月曜日の場合、次の月曜日が返される."""
+        basis_date = date(2026, 1, 5)  # 月曜日
+        result = RoutineCycle.WEEKLY_MON.next_date(basis_date)
+        assert result == date(2026, 1, 12)  # 月曜日
+
+    def test_weekly_tue_on_wednesday(self):
+        """WEEKLY_TUEの水曜日の場合、次の火曜日が返される."""
+        basis_date = date(2026, 1, 7)  # 水曜日
+        result = RoutineCycle.WEEKLY_TUE.next_date(basis_date)
+        assert result == date(2026, 1, 13)  # 火曜日
+
+    def test_weekly_tue_on_tuesday(self):
+        """WEEKLY_TUEの火曜日の場合、次の火曜日が返される."""
+        basis_date = date(2026, 1, 6)  # 火曜日
+        result = RoutineCycle.WEEKLY_TUE.next_date(basis_date)
+        assert result == date(2026, 1, 13)  # 火曜日
+
+    def test_weekly_thu_on_friday(self):
+        """WEEKLY_THUの金曜日の場合、次の木曜日が返される."""
+        basis_date = date(2026, 1, 9)  # 金曜日
+        result = RoutineCycle.WEEKLY_THU.next_date(basis_date)
+        assert result == date(2026, 1, 15)  # 木曜日
+
+    def test_weekly_thu_on_thursday(self):
+        """WEEKLY_THUの木曜日の場合、次の木曜日が返される."""
+        basis_date = date(2026, 1, 8)  # 木曜日
+        result = RoutineCycle.WEEKLY_THU.next_date(basis_date)
+        assert result == date(2026, 1, 15)  # 木曜日
+
+    def test_weekly_fri_on_saturday(self):
+        """WEEKLY_FRIの土曜日の場合、次の金曜日が返される."""
+        basis_date = date(2026, 1, 10)  # 土曜日
+        result = RoutineCycle.WEEKLY_FRI.next_date(basis_date)
+        assert result == date(2026, 1, 16)  # 金曜日
+
+    def test_weekly_fri_on_friday(self):
+        """WEEKLY_FRIの金曜日の場合、次の金曜日が返される."""
+        basis_date = date(2026, 1, 9)  # 金曜日
+        result = RoutineCycle.WEEKLY_FRI.next_date(basis_date)
+        assert result == date(2026, 1, 16)  # 金曜日
+
     def test_after_3_days(self):
         """AFTER_3_DAYSの場合、3日後が返される."""
         basis_date = date(2026, 1, 15)
@@ -109,6 +169,30 @@ class TestRoutineCycleNextDate:
         basis_date = date(2025, 12, 15)
         result = RoutineCycle.MONTHLY_1ST.next_date(basis_date)
         assert result == date(2026, 1, 1)
+
+    def test_monthly_2nd_before_2nd(self):
+        """MONTHLY_2NDで2日より前の場合、当月2日が返される."""
+        basis_date = date(2026, 1, 1)
+        result = RoutineCycle.MONTHLY_2ND.next_date(basis_date)
+        assert result == date(2026, 1, 2)
+
+    def test_monthly_2nd_after_2nd(self):
+        """MONTHLY_2NDで2日以降の場合、翌月2日が返される."""
+        basis_date = date(2026, 1, 3)
+        result = RoutineCycle.MONTHLY_2ND.next_date(basis_date)
+        assert result == date(2026, 2, 2)
+
+    def test_monthly_2nd_on_2nd(self):
+        """MONTHLY_2NDで2日の場合、翌月2日が返される."""
+        basis_date = date(2026, 1, 2)
+        result = RoutineCycle.MONTHLY_2ND.next_date(basis_date)
+        assert result == date(2026, 2, 2)
+
+    def test_monthly_2nd_december(self):
+        """MONTHLY_2NDで12月の場合、翌年1月2日が返される."""
+        basis_date = date(2025, 12, 15)
+        result = RoutineCycle.MONTHLY_2ND.next_date(basis_date)
+        assert result == date(2026, 1, 2)
 
     def test_monthly_25th_before_25th(self):
         """MONTHLY_25THで25日より前の場合、当月25日が返される."""
@@ -206,6 +290,36 @@ class TestRoutineCycleFromText:
         """from_textで「第1・3木」からFIRST_THIRD_THUが取得できる."""
         result = RoutineCycle.from_text("第1・3木")
         assert result == RoutineCycle.FIRST_THIRD_THU
+
+    def test_from_text_weekly_sun(self):
+        """from_textで「毎週日」からWEEKLY_SUNが取得できる."""
+        result = RoutineCycle.from_text("毎週日")
+        assert result == RoutineCycle.WEEKLY_SUN
+
+    def test_from_text_weekly_mon(self):
+        """from_textで「毎週月」からWEEKLY_MONが取得できる."""
+        result = RoutineCycle.from_text("毎週月")
+        assert result == RoutineCycle.WEEKLY_MON
+
+    def test_from_text_weekly_tue(self):
+        """from_textで「毎週火」からWEEKLY_TUEが取得できる."""
+        result = RoutineCycle.from_text("毎週火")
+        assert result == RoutineCycle.WEEKLY_TUE
+
+    def test_from_text_weekly_thu(self):
+        """from_textで「毎週木」からWEEKLY_THUが取得できる."""
+        result = RoutineCycle.from_text("毎週木")
+        assert result == RoutineCycle.WEEKLY_THU
+
+    def test_from_text_weekly_fri(self):
+        """from_textで「毎週金」からWEEKLY_FRIが取得できる."""
+        result = RoutineCycle.from_text("毎週金")
+        assert result == RoutineCycle.WEEKLY_FRI
+
+    def test_from_text_monthly_2nd(self):
+        """from_textで「毎月2日」からMONTHLY_2NDが取得できる."""
+        result = RoutineCycle.from_text("毎月2日")
+        assert result == RoutineCycle.MONTHLY_2ND
 
     def test_from_text_not_found(self):
         """from_textで存在しないテキストの場合、ValueErrorが発生する."""


### PR DESCRIPTION
# Pull Request

## 概要
RoutineCycleに個別の曜日指定（毎週日・月・火・木・金）と毎月2日のサイクルを追加しました。これまで毎週火・金のみの複合指定に対応していましたが、各曜日を個別に指定できるようになります。

## 変更の種類
- [x] ✨ New feature (新機能)

## 詳細な変更内容

### 追加されたRoutineCycle
- `WEEKLY_SUN`: 毎週日曜日
- `WEEKLY_MON`: 毎週月曜日
- `WEEKLY_TUE`: 毎週火曜日
- `WEEKLY_THU`: 毎週木曜日
- `WEEKLY_FRI`: 毎週金曜日
- `MONTHLY_2ND`: 毎月2日

### コード変更
1. **定数の追加・整理**: 曜日定数（SUNDAY, MONDAY, TUESDAY, THURSDAY, FRIDAY）を定義し、weekday計算の可読性を向上
2. **next_date()メソッドの拡張**: 各新しいRoutineCycleに対応するケースを追加
3. **テストの追加**: 各新機能について、基準日が対象曜日の場合と異なる曜日の場合のテストを実装

### 実装の特徴
- 各週次サイクルは、基準日が対象曜日の場合は次の週の同じ曜日を返す
- 月次サイクル（MONTHLY_2ND）は、基準日が2日より前の場合は当月2日、2日以降の場合は翌月2日を返す

## Conventional Commits
`feat: Add individual weekly and monthly routine cycles`

## チェックリスト
- [x] コードが正しくフォーマットされている
- [x] リンティングエラーがない
- [x] 型チェックが通る
- [x] テストが通る
- [x] 新機能にテストを追加した
- [ ] ドキュメントを更新した(該当なし)

https://claude.ai/code/session_019aE3PVy4295xqKxLZipMta