### PR TITLE
feat: Notion埋め込み用TODO表示API を追加

### DIFF
--- a/src/sandpiper/api.py
+++ b/src/sandpiper/api.py
@@ -14,7 +14,7 @@ from starlette.responses import Response, StreamingResponse
 from sandpiper.app.app import bootstrap
 
 from . import __version__
-from .routers import health, maintenance, notion, recipe
+from .routers import embed, health, maintenance, notion, recipe
 
 # 環境設定
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production")  # デフォルトは本番環境
@@ -140,3 +140,4 @@ app.include_router(health.router, prefix="/api", tags=["Health"])
 app.include_router(notion.router, prefix="/api", tags=["Notion"])
 app.include_router(maintenance.router, prefix="/api", tags=["Maintenance"])
 app.include_router(recipe.router, prefix="/api", tags=["Recipe"])
+app.include_router(embed.router, prefix="/api", tags=["Embed"])

--- a/src/sandpiper/routers/embed.py
+++ b/src/sandpiper/routers/embed.py
@@ -1,0 +1,39 @@
+"""Notion埋め込み用API"""
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from sandpiper.perform.infrastructure.notion_todo_repository import NotionTodoRepository
+from sandpiper.shared.valueobject.todo_status_enum import ToDoStatusEnum
+
+router = APIRouter(
+    prefix="/embed",
+    tags=["embed"],
+)
+
+# テンプレート設定
+templates = Jinja2Templates(directory=Path(__file__).parent.parent / "templates")
+
+
+@router.get("/todo/in-progress", response_class=HTMLResponse)
+async def get_in_progress_todo(request: Request) -> HTMLResponse:
+    """IN_PROGRESSステータスのTODOを1件表示する
+
+    Notionに埋め込むための画面。
+    """
+    todo_repository = NotionTodoRepository()
+    todos = todo_repository.find_by_status(ToDoStatusEnum.IN_PROGRESS)
+
+    # 1件だけ取得(なければNone)
+    current_todo = todos[0] if todos else None
+
+    return templates.TemplateResponse(
+        "embed_todo.html",
+        {
+            "request": request,
+            "todo": current_todo,
+        },
+    )

--- a/src/sandpiper/templates/embed_todo.html
+++ b/src/sandpiper/templates/embed_todo.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Current Task</title>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background-color: transparent;
+            padding: 8px;
+        }
+        .todo-card {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            border-radius: 8px;
+            padding: 16px;
+            color: white;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        .todo-label {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            opacity: 0.8;
+            margin-bottom: 4px;
+        }
+        .todo-title {
+            font-size: 16px;
+            font-weight: 600;
+            line-height: 1.4;
+            word-break: break-word;
+        }
+        .todo-meta {
+            margin-top: 8px;
+            font-size: 11px;
+            opacity: 0.8;
+            display: flex;
+            gap: 12px;
+        }
+        .todo-section {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .empty-state {
+            background: #f0f0f0;
+            border-radius: 8px;
+            padding: 16px;
+            text-align: center;
+            color: #666;
+        }
+        .empty-icon {
+            font-size: 24px;
+            margin-bottom: 8px;
+        }
+        .empty-text {
+            font-size: 14px;
+        }
+        .htmx-indicator {
+            display: none;
+        }
+        .htmx-request .htmx-indicator {
+            display: inline;
+        }
+    </style>
+</head>
+<body
+    hx-get="/api/embed/todo/in-progress"
+    hx-trigger="every 30s"
+    hx-swap="innerHTML"
+    hx-select="body > *"
+>
+    {% if todo %}
+    <div class="todo-card">
+        <div class="todo-label">In Progress</div>
+        <div class="todo-title">{{ todo.title }}</div>
+        {% if todo.section or todo.log_start_datetime %}
+        <div class="todo-meta">
+            {% if todo.section %}
+            <span class="todo-section">{{ todo.section.value }}</span>
+            {% endif %}
+            {% if todo.log_start_datetime %}
+            <span>{{ todo.log_start_datetime.strftime('%H:%M') }}~</span>
+            {% endif %}
+        </div>
+        {% endif %}
+    </div>
+    {% else %}
+    <div class="empty-state">
+        <div class="empty-icon">-</div>
+        <div class="empty-text">No active task</div>
+    </div>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## 概要
Notionに埋め込むための専用API エンドポイントを追加しました。現在進行中（IN_PROGRESS）のTODOを表示するHTMLレスポンスを返すエンドポイント `/api/embed/todo/in-progress` を実装しています。

## 変更の種類
- [x] ✨ New feature (新機能)

## 変更内容
### 新規追加
1. **`src/sandpiper/routers/embed.py`** - 埋め込み用APIルーター
   - `/api/embed/todo/in-progress` エンドポイント
   - IN_PROGRESSステータスのTODOを1件取得して表示
   - NotionTodoRepositoryを使用してデータを取得

2. **`src/sandpiper/templates/embed_todo.html`** - 埋め込み用HTMLテンプレート
   - グラデーション背景のカード型デザイン
   - TODOのタイトル、セクション、開始時刻を表示
   - HTMX統合で30秒ごとに自動更新
   - タスクがない場合は「No active task」を表示

### 修正
- `src/sandpiper/api.py` - embedルーターをインポートして登録

## Conventional Commits
```
feat: Notion埋め込み用TODO表示API を追加
```

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 技術的詳細
- **テンプレートエンジン**: Jinja2
- **フロントエンド**: HTMX（30秒ごとの自動更新）
- **スタイリング**: インラインCSS（Notion埋め込み対応）
- **レスポンス形式**: HTMLResponse

https://claude.ai/code/session_01VzjxCvcFw2qbwN8qjDydoj