### PR TITLE
refactor: Consolidate calendar date properties into single date range

### DIFF
--- a/src/sandpiper/plan/query/calendar_event_query.py
+++ b/src/sandpiper/plan/query/calendar_event_query.py
@@ -106,8 +106,8 @@ class NotionCalendarEventQuery:
         result: list[CalendarEventDto] = []
 
         for page in pages:
-            start_date_str = page.start_date.start if page.start_date.start else None
-            end_date_str = page.end_date.start if page.end_date.start else None
+            start_date_str = page.date_range.start if page.date_range.start else None
+            end_date_str = page.date_range.end if page.date_range.end else None
 
             if not start_date_str:
                 continue

--- a/src/sandpiper/review/query/calendar_query.py
+++ b/src/sandpiper/review/query/calendar_query.py
@@ -21,8 +21,8 @@ class NotionCalendarQuery:
         result = []
 
         for page in pages:
-            start_date_str = page.start_date.start if page.start_date.start else None
-            end_date_str = page.end_date.start if page.end_date.start else None
+            start_date_str = page.date_range.start if page.date_range.start else None
+            end_date_str = page.date_range.end if page.date_range.end else None
 
             if not start_date_str:
                 continue

--- a/src/sandpiper/shared/notion/databases/__init__.py
+++ b/src/sandpiper/shared/notion/databases/__init__.py
@@ -17,9 +17,8 @@ from sandpiper.shared.notion.databases import (
 )
 from sandpiper.shared.notion.databases.calendar import (
     CalendarEventCategory,
-    CalendarEventEndDate,
+    CalendarEventDateRange,
     CalendarEventName,
-    CalendarEventStartDate,
 )
 from sandpiper.shared.notion.databases.clips import (
     ClipsAutoFetchTitle,
@@ -93,9 +92,8 @@ class DatabaseId:
 
 __all__ = [
     "CalendarEventCategory",
-    "CalendarEventEndDate",
+    "CalendarEventDateRange",
     "CalendarEventName",
-    "CalendarEventStartDate",
     "ClipsAutoFetchTitle",
     "ClipsName",
     "ClipsTypeProp",

--- a/src/sandpiper/shared/notion/databases/calendar.py
+++ b/src/sandpiper/shared/notion/databases/calendar.py
@@ -14,13 +14,8 @@ class CalendarEventCategory(Select):  # type: ignore[misc]
     ...
 
 
-@notion_prop("開始日時")
-class CalendarEventStartDate(Date):  # type: ignore[misc]
-    ...
-
-
-@notion_prop("終了日時")
-class CalendarEventEndDate(Date):  # type: ignore[misc]
+@notion_prop("期間")
+class CalendarEventDateRange(Date):  # type: ignore[misc]
     ...
 
 
@@ -33,5 +28,4 @@ class CalendarEventPage(BasePage):  # type: ignore[misc]
 
     name: CalendarEventName
     category: CalendarEventCategory
-    start_date: CalendarEventStartDate
-    end_date: CalendarEventEndDate
+    date_range: CalendarEventDateRange


### PR DESCRIPTION
# Pull Request

## 概要
Notionカレンダーデータベースの日付プロパティを、開始日時と終了日時の2つの別々のプロパティから、単一の「期間」日付範囲プロパティに統合しました。これにより、Notionの日付範囲機能をより効果的に活用し、コードの複雑性を削減します。

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [x] ✨ New feature (新機能)
- [x] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [x] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
```
refactor!: Consolidate calendar date properties into single date range
```

## 変更内容
- `CalendarEventStartDate`と`CalendarEventEndDate`を削除し、`CalendarEventDateRange`に統合
- Notionプロパティ名を「開始日時」「終了日時」から「期間」に変更
- `CalendarEventPage`の`start_date`と`end_date`属性を`date_range`に統合
- `_calendar_event_page_to_domain()`で日付範囲の開始・終了値を正しく処理
- 3つのクエリファイルで日付アクセスパターンを更新（`page.start_date.start` → `page.date_range.start`など）
- `__init__.py`のエクスポートを更新

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->

https://claude.ai/code/session_01Ge9ZfoUV4bHiQ3xY7DBJ2a