### PR TITLE
chore: Fix Japanese comment formatting in test file

### DIFF
--- a/tests/perform/application/test_start_todo.py
+++ b/tests/perform/application/test_start_todo.py
@@ -52,7 +52,7 @@ class TestStartTodo:
         self.mock_repository.save.assert_called_once_with(mock_todo)
         self.mock_project_task_repository.find.assert_not_called()
         self.mock_project_task_repository.update_status.assert_not_called()
-        # コンテキストがなくてもイベントは発行される（context=Noneで）
+        # コンテキストがなくてもイベントは発行される(context=Noneで)
         self.mock_dispatcher.publish.assert_called_once()
         published_event = self.mock_dispatcher.publish.call_args[0][0]
         assert isinstance(published_event, TodoStarted)
@@ -305,7 +305,7 @@ class TestStartTodo:
         assert published_event.context == Context.OUTING  # 最初のコンテキストが使用される
 
     def test_execute_with_scheduled_duration(self):
-        """予定時間（所要時間）がイベントに含まれることをテスト"""
+        """予定時間(所要時間)がイベントに含まれることをテスト"""
         # Arrange
         page_id = "test-page-id"
         mock_todo = Mock()


### PR DESCRIPTION
## 概要
テストファイル内の日本語コメントの括弧の形式を統一しました。全角括弧「（）」から半角括弧「()」に変更しています。

## 変更の種類
- [x] 🧹 Code cleanup (コード整理)

## 詳細
`tests/perform/application/test_start_todo.py` 内の2つの日本語コメントの括弧形式を修正しました：
- Line 55: `（context=Noneで）` → `(context=Noneで)`
- Line 308: `（所要時間）` → `(所要時間)`

これにより、コード内の括弧形式の一貫性が向上します。

## Conventional Commits
`chore: Fix Japanese comment formatting in test file`

## チェックリスト
- [x] コードが正しくフォーマットされている
- [x] リンティングエラーがない
- [x] 型チェックが通る
- [x] テストが通る
- [x] 新機能にテストを追加した(該当なし)
- [x] ドキュメントを更新した(該当なし)

https://claude.ai/code/session_016qLbd7WmahRrUrcdbWNF1x