### PR TITLE
feat: サムデイリストから作成するTODOに予定日を設定

### DIFF
--- a/src/sandpiper/app/handlers/create_tomorrow_todo_list_handler.py
+++ b/src/sandpiper/app/handlers/create_tomorrow_todo_list_handler.py
@@ -123,7 +123,7 @@ class CreateTomorrowTodoListHandler(SpecialTodoHandler):
             self._create_repeat_task.execute(basis_date=basis_date)
 
             # サムデイリストからTODOを作成
-            someday_result = self._create_tasks_by_someday_list.execute()
+            someday_result = self._create_tasks_by_someday_list.execute(basis_date=basis_date)
 
             # カレンダーイベントからスケジュールタスクを作成
             schedule_result = self._create_schedule_tasks.execute(target_date=basis_date)

--- a/src/sandpiper/plan/application/create_tasks_by_someday_list.py
+++ b/src/sandpiper/plan/application/create_tasks_by_someday_list.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import date
 
 from sandpiper.plan.domain.someday_item import SomedayItem
 from sandpiper.plan.domain.someday_repository import SomedayRepository
@@ -25,8 +26,12 @@ class CreateTasksBySomedayList:
         self._someday_repository = someday_repository
         self._todo_repository = todo_repository
 
-    def execute(self) -> CreateTasksBySomedayListResult:
-        """「明日やる」にチェックの入っているサムデイリストからTODOを作成し、元のアイテムを削除"""
+    def execute(self, basis_date: date | None = None) -> CreateTasksBySomedayListResult:
+        """「明日やる」にチェックの入っているサムデイリストからTODOを作成し、元のアイテムを削除
+
+        Args:
+            basis_date: 処理基準日。TODOの「予定」プロパティに設定される。Noneの場合は設定しない。
+        """
         # 「明日やる」にチェックの入っているアイテムを取得
         tomorrow_items = self._someday_repository.fetch_tomorrow_items()
 
@@ -34,7 +39,7 @@ class CreateTasksBySomedayList:
 
         for item in tomorrow_items:
             # TODOを作成(タスク種別は「単発」)
-            self._create_todo_from_someday_item(item)
+            self._create_todo_from_someday_item(item, basis_date=basis_date)
             created_titles.append(item.title)
 
             # サムデイリストのアイテムを論理削除
@@ -45,10 +50,16 @@ class CreateTasksBySomedayList:
             created_titles=created_titles,
         )
 
-    def _create_todo_from_someday_item(self, item: SomedayItem) -> None:
-        """サムデイアイテムからTODOを作成"""
+    def _create_todo_from_someday_item(self, item: SomedayItem, basis_date: date | None = None) -> None:
+        """サムデイアイテムからTODOを作成
+
+        Args:
+            item: サムデイアイテム
+            basis_date: 処理基準日。TODOの「予定」プロパティに設定される。
+        """
         todo = ToDo(
             title=item.title,
             kind=ToDoKind.SINGLE,
+            scheduled_start_datetime=basis_date,
         )
         self._todo_repository.save(todo)


### PR DESCRIPTION
# Pull Request

## 概要
サムデイリストから「明日やる」タスクを作成する際に、処理基準日をTODOの「予定」プロパティに設定できるようにしました。これにより、明日のTODOリスト生成時に、作成されたタスクが正しい日付で予定されるようになります。

## 変更の種類
- [x] ✨ New feature (新機能)

## 詳細な変更内容

### `create_tomorrow_todo_list_handler.py`
- `_create_tasks_by_someday_list.execute()` の呼び出しに `basis_date` パラメータを追加

### `create_tasks_by_someday_list.py`
- `execute()` メソッドに `basis_date: date | None = None` パラメータを追加
- `_create_todo_from_someday_item()` メソッドに `basis_date` パラメータを追加
- 作成するToDo オブジェクトに `scheduled_start_datetime=basis_date` を設定
- メソッドのドキュメント文字列を更新

### `test_create_tasks_by_someday_list.py`
- `test_execute_with_basis_date_sets_scheduled_start_datetime()`: basis_dateを指定した場合、TODOの予定に正しく設定されることを検証
- `test_execute_without_basis_date_no_scheduled_datetime()`: basis_dateを指定しない場合、予定が設定されないことを検証

## Conventional Commits
`feat: サムデイリストから作成するTODOに予定日を設定`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [x] 新機能にテストを追加した
- [ ] ドキュメントを更新した(該当する場合)

https://claude.ai/code/session_011ZDSnLyZiEDCddrM1B6nBC