### PR TITLE
perf: Reduce redundant API calls in Notion repositories

### DIFF
--- a/src/sandpiper/plan/infrastructure/notion_routine_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_routine_repository.py
@@ -46,9 +46,8 @@ class NotionRoutineRepository(RoutineRepository):
         return routines
 
     def update(self, routine: Routine) -> None:
-        page = self.client.retrieve_page(routine.id)
-        page.set_prop(RoutineNextDate.from_start_date(routine.date))
-        self.client.update(page)
+        # Use update_page directly to avoid redundant retrieve_page API call
+        self.client.update_page(routine.id, [RoutineNextDate.from_start_date(routine.date)])
 
 
 if __name__ == "__main__":

--- a/src/sandpiper/plan/infrastructure/notion_todo_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_todo_repository.py
@@ -93,7 +93,8 @@ class NotionTodoRepository:
 
     def save(self, todo: ToDo, options: dict[str, Any] | None = None) -> InsertedToDo:
         options = options or {}
-        blocks = self._get_blocks_from_other_pages(todo)
+        # Use pre-fetched block_children from options if available, avoiding redundant API call
+        blocks = options.get("block_children") or self._get_blocks_from_other_pages(todo)
         notion_todo = TodoPage.generate(todo, options=options, blocks=blocks)
         page = self.client.create_page(notion_todo)
         return InsertedToDo(


### PR DESCRIPTION
## 概要
Notion APIへの冗長なAPI呼び出しを削減し、パフォーマンスを改善しました。

## 変更内容

### `notion_routine_repository.py`
- `update()` メソッドで `retrieve_page()` → `set_prop()` → `update()` の3ステップを、`update_page()` の直接呼び出しに統合
- 不要な中間ステップを排除し、API呼び出し回数を削減

### `notion_todo_repository.py`
- `save()` メソッドで、`options` パラメータから `block_children` が既に提供されている場合はそれを使用
- 不要な `_get_blocks_from_other_pages()` API呼び出しをスキップ

## 変更の種類
- [x] ⚡ Performance (パフォーマンス改善)

## Conventional Commits
`perf: Reduce redundant API calls in Notion repositories`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

https://claude.ai/code/session_01JRqPPzNwGEBnsKTLC3oW7h