### PR TITLE
fix: Handle missing start_date in Notion projects gracefully

### DIFF
--- a/src/sandpiper/plan/infrastructure/notion_project_repository.py
+++ b/src/sandpiper/plan/infrastructure/notion_project_repository.py
@@ -127,4 +127,11 @@ class NotionProjectRepository:
         pages: list[ProjectPage] = self.client.retrieve_database(
             database_id=project_db.DATABASE_ID, filter_param=filter_param, cls=ProjectPage
         )
-        return [page.to_inserted() for page in pages]
+        results: list[InsertedProject] = []
+        for page in pages:
+            try:
+                results.append(page.to_inserted())
+            except ValueError:
+                # start_dateが未設定のプロジェクトはスキップ
+                continue
+        return results


### PR DESCRIPTION
# Pull Request

## 概要
Notion プロジェクトデータベースから JIRA URL を持つプロジェクトを取得する際に、`start_date` が未設定のプロジェクトでエラーが発生する問題を修正しました。未設定のプロジェクトはスキップするようにしました。

## 変更の種類
- [x] 🐛 Bug fix (バグ修正)

## 詳細
`fetch_projects_with_jira_url()` メソッドで、`page.to_inserted()` の呼び出し時に `ValueError` が発生する場合があります。これは `start_date` が未設定のプロジェクトが原因です。

**変更内容:**
- リスト内包表記から明示的なループに変更
- `try-except` ブロックで `ValueError` をキャッチ
- `start_date` が未設定のプロジェクトをスキップして処理を継続

これにより、一部のプロジェクトが不完全でも、他の有効なプロジェクトは正常に取得できるようになります。

## Conventional Commits
```
fix: Handle missing start_date in Notion projects gracefully
```

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

https://claude.ai/code/session_01AnbaTVv35MB6ecyjRZFFJ6