### PR TITLE
chore: VaultパスをiCloudからローカル(~/obsidian/my-vault)へ移行

### DIFF
--- a/src/sandpiper/main.py
+++ b/src/sandpiper/main.py
@@ -1139,7 +1139,7 @@ def export_donelist(
         content = "\n".join(lines) + "\n" if lines else ""
 
         # Obsidian Vault に書き出し
-        vault_path = Path.home() / "Library/Mobile Documents/iCloud~md~obsidian/Documents/my-vault"
+        vault_path = Path.home() / "obsidian/my-vault"
         output_path = vault_path / "dailynote" / f"{target_date:%Y/%m/%d}" / "donelist.md"
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(content, encoding="utf-8")
@@ -1689,7 +1689,7 @@ def obsidian_list(
 
 
 _OBSIDIAN_SLACK_CHANNEL_ID = "C0AK05ELVM1"
-_VAULT_PATH = Path.home() / "Library/Mobile Documents/iCloud~md~obsidian/Documents/my-vault"
+_VAULT_PATH = Path.home() / "obsidian/my-vault"
 
 
 @_obsidian_app.command("migrate")


### PR DESCRIPTION
iCloudの読み書き遅延・同期問題を避けるためVaultを
~/obsidian/my-vault へ移動したことに伴い参照パスを更新。

# Pull Request

## 概要
<!-- 変更内容を簡潔に説明してください -->

## 変更の種類
- [ ] 🐛 Bug fix (バグ修正)
- [ ] ✨ New feature (新機能)
- [ ] 💥 Breaking change (破壊的変更)
- [ ] 📚 Documentation (ドキュメント)
- [ ] 🧹 Code cleanup (コード整理)
- [ ] ⚡ Performance (パフォーマンス改善)
- [ ] 🔧 Configuration (設定変更)

## Conventional Commits
<!-- release-pleaseが自動的にバージョンとCHANGELOGを更新するため、適切なコミットメッセージを使用してください -->

### 例:
- `feat: ユーザー認証機能を追加` (minor version bump)
- `fix: バリデーションエラーを修正` (patch version bump)
- `feat!: APIレスポンス形式を変更` (major version bump)
- `docs: README更新`
- `chore: 依存関係更新`

## チェックリスト
- [ ] コードが正しくフォーマットされている (`uv run ruff format .`)
- [ ] リンティングエラーがない (`uv run ruff check .`)
- [ ] 型チェックが通る (`uv run mypy`)
- [ ] テストが通る (`uv run pytest`)
- [ ] 新機能にテストを追加した(該当する場合)
- [ ] ドキュメントを更新した(該当する場合)

## 関連Issue
<!-- 関連するIssueがある場合は記載してください -->
Fixes #(issue number)
